### PR TITLE
fix: the default group is reset after restarting

### DIFF
--- a/src/main/resources/extensions/groups.yaml
+++ b/src/main/resources/extensions/groups.yaml
@@ -1,8 +1,0 @@
-apiVersion: core.halo.run/v1alpha1
-kind: LinkGroup
-metadata:
-  name: default
-spec:
-  displayName: 默认分组
-  priority: 0
-  links: [ "halo" ]


### PR DESCRIPTION
修复重启 Halo 或者插件之后，默认分组被重置的问题。

Fixes #10 

```release-note
修复重启 Halo 或者插件之后，默认分组被重置的问题。
```