### PR TITLE
fix: link management permission was assigned but still did not have permission

### DIFF
--- a/src/main/resources/extensions/roleTemplate.yaml
+++ b/src/main/resources/extensions/roleTemplate.yaml
@@ -11,7 +11,7 @@ metadata:
       ["plugin:links:view"]
 rules:
   - apiGroups: [ "core.halo.run" ]
-    resources: [ "links" ]
+    resources: [ "links", "linkgroups" ]
     verbs: [ "get", "list" ]
 ---
 apiVersion: v1alpha1
@@ -29,5 +29,5 @@ metadata:
       ["role-template-link-view"]
 rules:
   - apiGroups: [ "core.halo.run" ]
-    resources: [ "links" ]
+    resources: [ "links", "linkgroups" ]
     verbs: [ "create", "patch", "update", "delete", "deletecollection" ]


### PR DESCRIPTION
### What this PR does?
修复分配了友链管理权限仍无权限访问的问题
/kind improvement

/cc @halo-sigs/halo 
### how to test it?
1. 在此 PR 构建插件安装
2. 新建一个角色分配链接查看/管理权限，期望能正确获取到友链分组和友链

```release-note
修复给角色分配友链管理权限仍无权限访问的问题
```