### PR TITLE
fix: moving the currently selected link will move all links

### DIFF
--- a/console/src/views/LinkList.vue
+++ b/console/src/views/LinkList.vue
@@ -278,9 +278,15 @@ function getGroup(groupName: string) {
 }
 
 async function handleMoveInBatch(group: LinkGroup) {
-  const requests = links.value?.map((link) => {
+  const linksToUpdate = selectedLinks.value
+    ?.map((name) => {
+      return links.value?.find((link) => link.metadata.name === name);
+    })
+    .filter(Boolean) as Link[];
+
+  const requests = linksToUpdate.map((link) => {
     return apiClient.put<Link>(
-      `/apis/core.halo.run/v1alpha1/links/${link.metadata.name}`,
+      `/apis/core.halo.run/v1alpha1/links/${link?.metadata.name}`,
       {
         ...link,
         spec: {


### PR DESCRIPTION
修复移动选中链接时，会移动当前分组所有链接的问题。

Fixes https://github.com/halo-dev/halo/issues/4336

```release-note
修复移动选中链接时，会移动当前分组所有链接的问题。
```