### PR TITLE
feat: make logo form item type to attachment

### DIFF
--- a/console/src/components/LinkEditingModal.vue
+++ b/console/src/components/LinkEditingModal.vue
@@ -165,7 +165,7 @@ const handleSaveLink = async () => {
             validation="required"
             label="网站地址"
           ></FormKit>
-          <FormKit type="text" name="logo" label="Logo"></FormKit>
+          <FormKit type="attachment" name="logo" label="Logo"></FormKit>
           <FormKit type="textarea" name="description" label="描述"></FormKit>
         </div>
       </div>


### PR DESCRIPTION
修改链接表单的 Logo 输入框类型为 `attachment`，用于从附件库选择图片。

/kind improvement

Ref https://github.com/halo-sigs/plugin-links/issues/39#issuecomment-1659972812

```release-note
修改链接表单的 Logo 输入框类型为 `attachment`，用于从附件库选择图片。
```