### PR TITLE
chore: update halo requires

### DIFF
--- a/src/main/resources/plugin.yaml
+++ b/src/main/resources/plugin.yaml
@@ -4,7 +4,7 @@ metadata:
   name: PluginLinks
 spec:
   version: 1.2.0
-  requires: ">=2.4.0"
+  requires: ">=2.8.0"
   author:
     name: Halo OSS Team
     website: https://github.com/halo-dev


### PR DESCRIPTION
更新 Halo 依赖为 >=2.8.0

```release-note
None
```