### PR TITLE
Restrict minimal version of Halo to 2.8.0

### DIFF
--- a/src/main/resources/plugin.yaml
+++ b/src/main/resources/plugin.yaml
@@ -4,7 +4,7 @@ metadata:
   name: PluginLinks
 spec:
   version: 1.2.0
-  requires: ">=2.4.0"
+  requires: ">=2.8.0"
   author:
     name: Halo OSS Team
     website: https://github.com/halo-dev


### PR DESCRIPTION
Due to https://github.com/halo-sigs/plugin-links/pull/36 and https://github.com/halo-dev/halo/pull/4212, the minimal version of Halo should be 2.8.0 instead of 2.4.0.

```release-note
None
```