### PR TITLE
fix: create link in incorrect group

### DIFF
--- a/console/src/components/GroupList.vue
+++ b/console/src/components/GroupList.vue
@@ -179,13 +179,13 @@ function onEditingModalClose() {
       </Draggable>
     </Transition>
 
-    <template v-if="!isLoading" #footer>
+    <template v-if="!isLoading" #item="{ element: group }" #footer>
       <Transition appear name="fade">
         <VButton
           v-permission="['plugin:links:manage']"
           block
           type="secondary"
-          @click="handleOpenEditingModal(undefined)"
+          @click="handleOpenEditingModal(group)"
         >
           新建
         </VButton>


### PR DESCRIPTION
修复创建链接不会在已选择的分组中

Fixes #48 

```
修复创建链接不会在已选择的分组中
```