### PR TITLE
feat: adapt to the comment plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ group：plugin.halo.run
 
 kind: Plugin
 
-name: ${plugin_name}
+name: ${pluginName}
 
 #### 示例
 
@@ -186,7 +186,7 @@ name: ${plugin_name}
     <halo:comment
         group="plugin.halo.run"
         kind="Plugin"
-        th:attr="name=${plugin_name}"
+        th:attr="name=${pluginName}"
     />
 </div>
 ```

--- a/README.md
+++ b/README.md
@@ -167,6 +167,30 @@ List<[#LinkGroupVo](#linkgroupvo)>
 </th:block>
 ```
 
+### 评论适配
+
+主题开发者可以参考 [自定义标签](https://docs.halo.run/developer-guide/theme/template-tag/#halocomment)，来为友情链接接入评论功能。
+
+#### 参数值
+
+group：plugin.halo.run
+
+kind: Plugin
+
+name: ${plugin_name}
+
+#### 示例
+
+```html
+<div th:if="${haloCommentEnabled}">
+    <halo:comment
+        group="plugin.halo.run"
+        kind="Plugin"
+        th:attr="name=${plugin_name}"
+    />
+</div>
+```
+
 ### 类型定义
 
 #### LinkVo

--- a/build.gradle
+++ b/build.gradle
@@ -47,4 +47,5 @@ tasks.named("compileJava").configure {
 
 halo {
     version = '2.15'
+    debug = true
 }

--- a/console/package.json
+++ b/console/package.json
@@ -12,8 +12,9 @@
     "prettier": "prettier --write './src/**/*.{vue,js,jsx,ts,tsx,css,scss,json,yml,yaml,html}'"
   },
   "dependencies": {
-    "@halo-dev/components": "^1.7.0",
-    "@halo-dev/console-shared": "^2.8.0",
+    "@halo-dev/components": "^2.15.0",
+    "@halo-dev/console-shared": "^2.15.0",
+    "@halo-dev/api-client": "^2.15.0",
     "@tanstack/vue-query": "^4.32.0",
     "@vueuse/core": "^10.2.1",
     "@vueuse/router": "^10.2.1",

--- a/console/pnpm-lock.yaml
+++ b/console/pnpm-lock.yaml
@@ -5,12 +5,15 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@halo-dev/api-client':
+    specifier: ^2.15.0
+    version: 2.16.0
   '@halo-dev/components':
-    specifier: ^1.7.0
-    version: 1.7.0(vue-router@4.2.4)(vue@3.3.4)
+    specifier: ^2.15.0
+    version: 2.16.0(vue-router@4.2.4)(vue@3.3.4)
   '@halo-dev/console-shared':
-    specifier: ^2.8.0
-    version: 2.8.0(vue-router@4.2.4)(vue@3.3.4)
+    specifier: ^2.15.0
+    version: 2.16.0(vue-router@4.2.4)(vue@3.3.4)
   '@tanstack/vue-query':
     specifier: ^4.32.0
     version: 4.32.0(vue@3.3.4)
@@ -745,38 +748,46 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@floating-ui/core@0.3.1:
-    resolution: {integrity: sha512-ensKY7Ub59u16qsVIFEo2hwTCqZ/r9oZZFh51ivcLGHfUwTn8l1Xzng8RJUe91H/UP8PeqeBronAGx0qmzwk2g==}
-    dev: false
-
-  /@floating-ui/dom@0.1.10:
-    resolution: {integrity: sha512-4kAVoogvQm2N0XE0G6APQJuCNuErjOfPW8Ux7DFxh8+AfugWflwVJ5LDlHOwrwut7z/30NUvdtHzQ3zSip4EzQ==}
+  /@floating-ui/core@1.6.2:
+    resolution: {integrity: sha512-+2XpQV9LLZeanU4ZevzRnGFg2neDeKHgFLjP6YLW+tly0IvrhqT4u8enLGjLH3qeh85g19xY5rsAusfwTdn5lg==}
     dependencies:
-      '@floating-ui/core': 0.3.1
+      '@floating-ui/utils': 0.2.2
     dev: false
 
-  /@halo-dev/api-client@2.8.0:
-    resolution: {integrity: sha512-mVfYYO437TOshRppCnfYBbc4pvbpNWPmlsv8UAWr3F3Zs3LafcHcF4hb7rq03qfEahsnoLtX8jXVWjmFtf4xqw==}
+  /@floating-ui/dom@1.1.1:
+    resolution: {integrity: sha512-TpIO93+DIujg3g7SykEAGZMDtbJRrmnYRCNYSjJlvIbGhBjRSNTLVbNeDQBrzy9qDgUbiWdc7KA0uZHZ2tJmiw==}
+    dependencies:
+      '@floating-ui/core': 1.6.2
     dev: false
 
-  /@halo-dev/components@1.7.0(vue-router@4.2.4)(vue@3.3.4):
-    resolution: {integrity: sha512-iJ71eP2VwOMyxrTJGlYLaGLH4w8pz61pnuu5HX2yaYpDJVd8K//Hs4XmWWuzQSw361mPwBfGduQLvBA+/WOhHQ==}
+  /@floating-ui/utils@0.2.2:
+    resolution: {integrity: sha512-J4yDIIthosAsRZ5CPYP/jQvUAQtlZTTD/4suA08/FEnlxqW3sKS9iAhgsa9VYLZ6vDHn/ixJgIqRQPotoBjxIw==}
+    dev: false
+
+  /@halo-dev/api-client@2.16.0:
+    resolution: {integrity: sha512-oSrP+84p8HZzRjO4DgGxkAJwN8hwHpOUlFhO3PdEi3F2QC3bwH5+LmYJgHilVP9KEMRY+uplE//v908kfkYLhg==}
+    dev: false
+
+  /@halo-dev/components@2.16.0(vue-router@4.2.4)(vue@3.3.4):
+    resolution: {integrity: sha512-r4bGGmR9Hz/m1hnL1Ha0iWwQM2ImtB4DfJOMOfsABP0eGCZL1hXv/08JE05sP9g7gtLlRNQ6xTPLKyp6E6WY4g==}
     peerDependencies:
-      vue: ^3.2.37
-      vue-router: ^4.0.16
+      vue: ^3.4.27
+      vue-router: ^4.3.2
     dependencies:
-      floating-vue: 2.0.0-beta.20(vue@3.3.4)
+      floating-vue: 5.2.2(vue@3.3.4)
       vue: 3.3.4
       vue-router: 4.2.4(vue@3.3.4)
+    transitivePeerDependencies:
+      - '@nuxt/kit'
     dev: false
 
-  /@halo-dev/console-shared@2.8.0(vue-router@4.2.4)(vue@3.3.4):
-    resolution: {integrity: sha512-Zhi5FbVrdzSSaaT6i2xh8JOhmi9keetjg8zrYd+tEp4Iy+mPke4ZA4SIYaO1Bkwr9MD5BZ+sNswgYCPd36wYaw==}
+  /@halo-dev/console-shared@2.16.0(vue-router@4.2.4)(vue@3.3.4):
+    resolution: {integrity: sha512-skt6lvZsJibHYJ/87ofH8rnyVF4SNzleZMh58xhGyQAZcSS09YgXJGd39DqGqxdWSAx/lX3O08b+r/xcJIPc3g==}
     peerDependencies:
-      vue: ^3.2.37
-      vue-router: ^4.0.16
+      vue: ^3.4.27
+      vue-router: ^4.3.2
     dependencies:
-      '@halo-dev/api-client': 2.8.0
+      '@halo-dev/api-client': 2.16.0
       vue: 3.3.4
       vue-router: 4.2.4(vue@3.3.4)
     dev: false
@@ -2572,12 +2583,16 @@ packages:
     resolution: {integrity: sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==}
     dev: true
 
-  /floating-vue@2.0.0-beta.20(vue@3.3.4):
-    resolution: {integrity: sha512-N68otcpp6WwcYC7zP8GeJqNZVdfvS7tEY88lwmuAHeqRgnfWx1Un8enzLxROyVnBDZ3TwUoUdj5IFg+bUT7JeA==}
+  /floating-vue@5.2.2(vue@3.3.4):
+    resolution: {integrity: sha512-afW+h2CFafo+7Y9Lvw/xsqjaQlKLdJV7h1fCHfcYQ1C4SVMlu7OAekqWgu5d4SgvkBVU0pVpLlVsrSTBURFRkg==}
     peerDependencies:
+      '@nuxt/kit': ^3.2.0
       vue: ^3.2.0
+    peerDependenciesMeta:
+      '@nuxt/kit':
+        optional: true
     dependencies:
-      '@floating-ui/dom': 0.1.10
+      '@floating-ui/dom': 1.1.1
       vue: 3.3.4
       vue-resize: 2.0.0-alpha.1(vue@3.3.4)
     dev: false

--- a/console/src/index.ts
+++ b/console/src/index.ts
@@ -1,9 +1,14 @@
 import "./styles/tailwind.css";
 import "./styles/index.css";
-import { definePlugin } from "@halo-dev/console-shared";
+import {
+  definePlugin,
+  type CommentSubjectRefProvider,
+  type CommentSubjectRefResult,
+} from "@halo-dev/console-shared";
 import LinkList from "@/views/LinkList.vue";
 import { markRaw } from "vue";
 import RiLinksLine from "~icons/ri/links-line";
+import type { Extension } from "@halo-dev/api-client/index";
 
 export default definePlugin({
   components: {},
@@ -25,4 +30,24 @@ export default definePlugin({
       },
     },
   ],
+  extensionPoints: {
+    "comment:subject-ref:create": (): CommentSubjectRefProvider[] => {
+      return [
+        {
+          kind: "Plugin",
+          group: "plugin.halo.run",
+          resolve: (subject: Extension): CommentSubjectRefResult => {
+            return {
+              label: "友链",
+              title: "友链页面",
+              externalUrl: "/links",
+              route: {
+                name: "Links",
+              },
+            };
+          },
+        },
+      ];
+    },
+  },
 });

--- a/src/main/java/run/halo/links/LinkCommentSubject.java
+++ b/src/main/java/run/halo/links/LinkCommentSubject.java
@@ -1,0 +1,44 @@
+package run.halo.links;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+import reactor.core.publisher.Mono;
+import run.halo.app.content.comment.CommentSubject;
+import run.halo.app.core.extension.Plugin;
+import run.halo.app.extension.GroupVersionKind;
+import run.halo.app.extension.ReactiveExtensionClient;
+import run.halo.app.extension.Ref;
+import run.halo.app.plugin.PluginContext;
+
+/**
+ * @author LIlGG
+ */
+@Component
+@RequiredArgsConstructor
+public class LinkCommentSubject implements CommentSubject<Plugin> {
+    
+    private final ReactiveExtensionClient client;
+    
+    private final PluginContext pluginContext;
+    
+    @Override
+    public Mono<Plugin> get(String name) {
+        return client.get(Plugin.class, name);
+    }
+    
+    @Override
+    public Mono<SubjectDisplay> getSubjectDisplay(String name) {
+        return Mono.just(new SubjectDisplay("", "", ""));
+    }
+    
+    @Override
+    public boolean supports(Ref ref) {
+        Assert.notNull(ref, "Subject ref must not be null.");
+        GroupVersionKind groupVersionKind = new GroupVersionKind(ref.getGroup(),
+            ref.getVersion(), ref.getKind()
+        );
+        return GroupVersionKind.fromExtension(Plugin.class).equals(
+            groupVersionKind) && pluginContext.getName().equals(ref.getName());
+    }
+}

--- a/src/main/java/run/halo/links/LinkCommentSubject.java
+++ b/src/main/java/run/halo/links/LinkCommentSubject.java
@@ -29,7 +29,7 @@ public class LinkCommentSubject implements CommentSubject<Plugin> {
     
     @Override
     public Mono<SubjectDisplay> getSubjectDisplay(String name) {
-        return Mono.just(new SubjectDisplay("", "", ""));
+        return Mono.just(new SubjectDisplay("友情链接", "/links", "友情链接"));
     }
     
     @Override

--- a/src/main/java/run/halo/links/LinkRouter.java
+++ b/src/main/java/run/halo/links/LinkRouter.java
@@ -31,6 +31,7 @@ import run.halo.app.extension.ReactiveExtensionClient;
 import run.halo.app.extension.router.IListRequest;
 import run.halo.app.extension.router.SortableRequest;
 import run.halo.app.extension.router.selector.FieldSelector;
+import run.halo.app.plugin.PluginContext;
 import run.halo.links.finders.LinkFinder;
 import run.halo.links.vo.LinkGroupVo;
 
@@ -41,12 +42,14 @@ public class LinkRouter {
     private final LinkFinder linkFinder;
     private final ReactiveExtensionClient client;
     private final String tag = "api.plugin.halo.run/v1alpha1/Link";
+    private final PluginContext pluginContext;
 
     @Bean
     RouterFunction<ServerResponse> linkTemplateRoute() {
         return route(GET("/links"),
             request -> ServerResponse.ok().render("links",
-                Map.of("groups", linkGroups())));
+                Map.of("groups", linkGroups(),
+                    "plugin_name", pluginContext.getName())));
     }
 
     @Bean

--- a/src/main/java/run/halo/links/LinkRouter.java
+++ b/src/main/java/run/halo/links/LinkRouter.java
@@ -49,7 +49,7 @@ public class LinkRouter {
         return route(GET("/links"),
             request -> ServerResponse.ok().render("links",
                 Map.of("groups", linkGroups(),
-                    "plugin_name", pluginContext.getName())));
+                    "pluginName", pluginContext.getName())));
     }
 
     @Bean


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

为友链页面适配评论插件。在当前的 `links.html` 模板下，增加如下 HTML 即可为友链页面增加评论组件。

```html
<div th:if="${haloCommentEnabled}">
    <halo:comment
        group="plugin.halo.run"
        kind="Plugin"
        th:attr="name=${plugin_name}"
    />
</div>
```

提交后将在评论页面展示相关信息并支持跳转至评论页面。

<img width="545" alt="image" src="https://github.com/halo-sigs/plugin-links/assets/31335418/a6821330-f853-4230-a947-454d33149e8b">

#### How to test it?

测试友链页面添加评论组件。
测试提交评论后，在评论列表是否能够显示友情链接的 subject 信息。

#### Which issue(s) this PR fixes:

Fixes #63 

#### Does this PR introduce a user-facing change?
```release-note
为友情链接页面适配评论插件
```
