### PR TITLE
feat: add page title configuration item

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,20 @@ List<[#LinkGroupVo](#linkgroupvo)>
 </th:block>
 ```
 
+#### 变量
+
+linksTitle
+
+##### 变量类型
+
+String
+
+##### 示例
+
+```html
+<h2 th:text="${linksTitle}"></h2>
+```
+
 ### Finder API
 
 #### listBy(group)

--- a/src/main/java/run/halo/links/LinkRouter.java
+++ b/src/main/java/run/halo/links/LinkRouter.java
@@ -32,6 +32,7 @@ import run.halo.app.extension.router.IListRequest;
 import run.halo.app.extension.router.SortableRequest;
 import run.halo.app.extension.router.selector.FieldSelector;
 import run.halo.app.plugin.PluginContext;
+import run.halo.app.plugin.ReactiveSettingFetcher;
 import run.halo.links.finders.LinkFinder;
 import run.halo.links.vo.LinkGroupVo;
 
@@ -43,13 +44,15 @@ public class LinkRouter {
     private final ReactiveExtensionClient client;
     private final String tag = "api.plugin.halo.run/v1alpha1/Link";
     private final PluginContext pluginContext;
-
+    private final ReactiveSettingFetcher settingFetcher;
+    
     @Bean
     RouterFunction<ServerResponse> linkTemplateRoute() {
         return route(GET("/links"),
             request -> ServerResponse.ok().render("links",
                 Map.of("groups", linkGroups(),
-                    "pluginName", pluginContext.getName())));
+                    "pluginName", pluginContext.getName(),
+                    "linksTitle", getLinkTitle())));
     }
 
     @Bean
@@ -149,5 +152,11 @@ public class LinkRouter {
     private Mono<List<LinkGroupVo>> linkGroups() {
         return linkFinder.groupBy()
             .collectList();
+    }
+    
+    Mono<String> getLinkTitle() {
+        return this.settingFetcher.get("base")
+            .map(setting -> setting.get("title").asText())
+            .defaultIfEmpty("链接");
     }
 }

--- a/src/main/resources/extensions/settings.yaml
+++ b/src/main/resources/extensions/settings.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1alpha1
+kind: Setting
+metadata:
+  name: plugin-links-settings
+spec:
+  forms:
+    - group: base
+      label: 基本设置
+      formSchema:
+        - $formkit: text
+          label: 页面标题
+          name: title
+          validation: required
+          value: '链接'

--- a/src/main/resources/plugin.yaml
+++ b/src/main/resources/plugin.yaml
@@ -8,6 +8,8 @@ spec:
     name: Halo OSS Team
     website: https://github.com/halo-dev
   logo: logo.png
+  configMapName: plugin-links-configmap
+  settingName: plugin-links-settings
   homepage: https://github.com/halo-sigs/plugin-links
   displayName: "链接管理"
   description: "链接管理模块"


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

增加页面标题配置项，默认标题为 `链接`。并向主题端提供 `linksTitle` 变量。

#### Which issue(s) this PR fixes:

Fixes #56 

#### Does this PR introduce a user-facing change?
```release-note
增加页面标题配置项并提供给主题。
```
