### PR TITLE
fix: display issue when no groups are present

### DIFF
--- a/console/src/views/LinkList.vue
+++ b/console/src/views/LinkList.vue
@@ -375,10 +375,7 @@ async function handleMove(link: Link, group: LinkGroup) {
                 <div
                   class="links-flex links-w-full links-flex-1 sm:links-w-auto"
                 >
-                  <SearchInput
-                    v-if="!selectedLinks.length"
-                    v-model="keyword"
-                  />
+                  <SearchInput v-if="!selectedLinks.length" v-model="keyword" />
                   <VSpace v-else>
                     <VButton type="danger" @click="handleDeleteInBatch">
                       删除
@@ -528,7 +525,11 @@ async function handleMove(link: Link, group: LinkGroup) {
                       <VDropdownItem @click="handleOpenCreateModal(link)">
                         编辑
                       </VDropdownItem>
-                      <VDropdown placement="left" :triggers="['click']">
+                      <VDropdown
+                        v-if="groups?.length"
+                        placement="left"
+                        :triggers="['click']"
+                      >
                         <VDropdownItem> 移动 </VDropdownItem>
                         <template #popper>
                           <template


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

当目前链接没有分组时，将不会显示移动按钮。

#### How to test it?

测试不存在分组以及存在分组时，移动按钮是否显示。

#### Which issue(s) this PR fixes:

Fixes #73 

#### Does this PR introduce a user-facing change?
```release-note
解决没有分组时点击移动会出现空白项的问题
```
