### PR TITLE
[codex] Compact empty link group state

### DIFF
--- a/console/src/components/LinksCard.vue
+++ b/console/src/components/LinksCard.vue
@@ -13,7 +13,6 @@ import {
   VCard,
   VDropdown,
   VDropdownItem,
-  VEmpty,
   VSpace,
 } from "@halo-dev/components";
 import { useQueryClient } from "@tanstack/vue-query";
@@ -231,11 +230,7 @@ function handleDelete({ deleteLinks }: { deleteLinks: boolean }) {
         </div>
       </div>
     </template>
-    <VEmpty v-if="!links.length" title="无数据" message="此分组下暂无链接">
-      <template #actions>
-        <VButton type="secondary" size="sm" @click="creationModalVisible = true">新建</VButton>
-      </template>
-    </VEmpty>
+    <div v-if="!links.length" class=":uno: px-4 py-3 text-center text-sm text-gray-500">此分组下暂无链接</div>
     <div class=":uno: grid grid-cols-2 gap-2.5 2xl:grid-cols-7 lg:grid-cols-4 md:grid-cols-3 xl:grid-cols-6" v-else>
       <LinkBadge
         v-for="link in links"


### PR DESCRIPTION
## Summary

- Replace the full `VEmpty` empty-state block for empty link groups with a compact single-line message.
- Remove the duplicate empty-state create button because the card header already exposes the create action.
- Center the empty-state message so empty groups still read as intentional UI sections.

## Why

Empty groups are valid because users may keep them for later use, but the previous illustration-based empty state consumed too much vertical space when several empty groups existed.

Closes #122.

## Validation

- `pnpm build`
- `./gradlew reload`
- Verified the `/console/links` UI in the in-app browser with a temporary empty group.

```release-note
优化空分组的 UI 状态
```
