### PR TITLE
Exclude slf4j-api from nitrite dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,9 +14,15 @@ dependencies {
     implementation platform('run.halo.tools.platform:plugin:2.24.0')
     compileOnly 'run.halo.app:api'
     implementation 'com.rometools:rome:2.1.0'
-    implementation 'org.dizitart:nitrite:4.3.2'
-    implementation 'org.dizitart:nitrite-mvstore-adapter:4.3.2'
-    implementation 'org.dizitart:nitrite-support:4.3.2'
+    implementation('org.dizitart:nitrite:4.3.2') {
+        exclude group: 'org.slf4j', module: 'slf4j-api'
+    }
+    implementation('org.dizitart:nitrite-mvstore-adapter:4.3.2') {
+        exclude group: 'org.slf4j', module: 'slf4j-api'
+    }
+    implementation('org.dizitart:nitrite-support:4.3.2') {
+        exclude group: 'org.slf4j', module: 'slf4j-api'
+    }
 
     testImplementation 'run.halo.app:api'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'


### PR DESCRIPTION
Remove slf4j-api transitive dependency from nitrite 4.3.2 modules. Already provided by Halo platform BOM.