### PR TITLE
fix(links): Ensure that groups without links are displayed normally

### DIFF
--- a/console/src/composables/use-link-fetch.ts
+++ b/console/src/composables/use-link-fetch.ts
@@ -19,9 +19,6 @@ export interface GroupWithLinks {
 }
 
 function groupLinks(groups: LinkGroup[], links: Link[]) {
-  if (!links.length) {
-    return [{ links: [] }];
-  }
 
   const groupNames = groups.map((group) => group.metadata.name);
 


### PR DESCRIPTION
## 问题描述
当某个分组下没有任何链接时，该分组在链接管理页面完全不显示，导致用户无法看到空分组。

## 根本原因
`use-link-fetch.ts` 中的 `groupLinks` 函数在 `links.length === 0` 时直接返回 `[{ links: [] }]`，导致空分组被过滤掉。

## 解决方案
移除 `groupLinks` 函数中的早期返回判断，确保所有分组（包括空分组）都被包含在返回结果中。

## 修改文件
- `src/composables/use-link-fetch.ts`

## 修改内容
```diff
function groupLinks(groups: LinkGroup[], links: Link[]) {
-  if (!links.length) {
-    return [{ links: [] }];
-  }
-
  const groupNames = groups.map((group) => group.metadata.name);
  // ... 其余代码不变
}
```
Closes #135