### PR TITLE
Refine link application detail and review modal styles

### DIFF
--- a/console/src/components/LinkApplicationDetailModal.vue
+++ b/console/src/components/LinkApplicationDetailModal.vue
@@ -16,21 +16,11 @@ import {
   linkApplicationReviewMode,
   linkApplicationStatusMeta,
 } from "@/utils/link-application-review";
-import {
-  Dialog,
-  Toast,
-  VAlert,
-  VButton,
-  VDescription,
-  VDescriptionItem,
-  VLoading,
-  VModal,
-  VSpace,
-  VTag,
-} from "@halo-dev/components";
+import { Dialog, Toast, VAlert, VButton, VLoading, VModal, VSpace, VTag } from "@halo-dev/components";
 import { useQueryClient } from "@tanstack/vue-query";
 import { computed, reactive, useTemplateRef } from "vue";
 import MingcuteEarth3Line from "~icons/mingcute/earth-3-line";
+import MingcuteMailLine from "~icons/mingcute/mail-line";
 import LinkApplicationOriginDetails from "./LinkApplicationOriginDetails.vue";
 import LinkApplicationSourceBadge from "./LinkApplicationSourceBadge.vue";
 
@@ -192,18 +182,17 @@ function handleDelete() {
 <template>
   <VModal ref="modal" :title="modalTitle" :width="600" :mount-to-body="true" :centered="false" @close="emit('close')">
     <div class=":uno: space-y-4">
-      <div class=":uno: overflow-hidden border border-gray-100 rounded">
-        <VDescription>
-          <VDescriptionItem label="状态" vertical-center>
-            <VTag :type="statusMeta.tagType" size="sm">
-              {{ statusMeta.label }}
-            </VTag>
-          </VDescriptionItem>
-          <VDescriptionItem label="来源" vertical-center>
-            <LinkApplicationSourceBadge :application="application" />
-          </VDescriptionItem>
-          <VDescriptionItem v-if="application.spec.email" label="联系邮箱" :content="application.spec.email" />
-        </VDescription>
+      <div
+        class=":uno: flex flex-wrap items-center gap-x-4 gap-y-2 border border-gray-200 rounded-lg bg-gray-50 px-3.5 py-2.5"
+      >
+        <VTag :type="statusMeta.tagType" size="sm">
+          {{ statusMeta.label }}
+        </VTag>
+        <LinkApplicationSourceBadge :application="application" />
+        <span v-if="application.spec.email" class=":uno: inline-flex items-center gap-1.5 text-sm text-gray-600">
+          <MingcuteMailLine class=":uno: size-3.5 text-gray-400" />
+          {{ application.spec.email }}
+        </span>
       </div>
 
       <VAlert v-if="reviewMode === 'resume'" title="审批已保留" type="info" :closable="false">
@@ -274,37 +263,48 @@ function handleDelete() {
       </FormKit>
 
       <!-- Frozen fields for approving / terminal applications -->
-      <div v-else class=":uno: overflow-hidden border border-gray-100 rounded">
-        <VDescription>
-          <VDescriptionItem label="网站名称" :content="frozenFields.displayName" />
-          <VDescriptionItem label="链接地址">
-            <a :href="frozenFields.url" target="_blank" class=":uno: text-blue-600 hover:underline">
+      <dl v-else class=":uno: overflow-hidden border border-gray-200 rounded-lg divide-y divide-gray-100">
+        <div class=":uno: flex gap-3 px-3.5 py-2.5 text-sm">
+          <dt class=":uno: w-18 shrink-0 text-gray-500">网站名称</dt>
+          <dd class=":uno: min-w-0 flex-1 break-all text-gray-900">{{ frozenFields.displayName }}</dd>
+        </div>
+        <div class=":uno: flex gap-3 px-3.5 py-2.5 text-sm">
+          <dt class=":uno: w-18 shrink-0 text-gray-500">链接地址</dt>
+          <dd class=":uno: min-w-0 flex-1">
+            <a :href="frozenFields.url" target="_blank" class=":uno: break-all text-blue-600 hover:underline">
               {{ frozenFields.url }}
             </a>
-          </VDescriptionItem>
-          <VDescriptionItem v-if="frozenFields.logo" label="Logo">
-            <span class=":uno: break-all">{{ frozenFields.logo }}</span>
-          </VDescriptionItem>
-          <VDescriptionItem v-if="frozenFields.description" label="简介">
-            <span class=":uno: whitespace-pre-wrap">{{ frozenFields.description }}</span>
-          </VDescriptionItem>
-          <VDescriptionItem label="分配分组" :content="frozenGroupLabel" />
-          <VDescriptionItem v-if="frozenFields.backlink" label="反链地址" vertical-center>
-            <a
-              :href="frozenFields.backlink"
-              target="_blank"
-              class=":uno: flex-1 truncate text-blue-600 hover:underline"
-            >
+          </dd>
+        </div>
+        <div v-if="frozenFields.logo" class=":uno: flex gap-3 px-3.5 py-2.5 text-sm">
+          <dt class=":uno: w-18 shrink-0 text-gray-500">Logo</dt>
+          <dd class=":uno: min-w-0 flex-1 break-all text-gray-900">{{ frozenFields.logo }}</dd>
+        </div>
+        <div v-if="frozenFields.description" class=":uno: flex gap-3 px-3.5 py-2.5 text-sm">
+          <dt class=":uno: w-18 shrink-0 text-gray-500">简介</dt>
+          <dd class=":uno: min-w-0 flex-1 whitespace-pre-wrap text-gray-900">{{ frozenFields.description }}</dd>
+        </div>
+        <div class=":uno: flex gap-3 px-3.5 py-2.5 text-sm">
+          <dt class=":uno: w-18 shrink-0 text-gray-500">分配分组</dt>
+          <dd class=":uno: min-w-0 flex-1 text-gray-900">{{ frozenGroupLabel }}</dd>
+        </div>
+        <div v-if="frozenFields.backlink" class=":uno: flex gap-3 px-3.5 py-2.5 text-sm">
+          <dt class=":uno: w-18 shrink-0 text-gray-500">反链地址</dt>
+          <dd class=":uno: min-w-0 flex-1">
+            <a :href="frozenFields.backlink" target="_blank" class=":uno: break-all text-blue-600 hover:underline">
               {{ frozenFields.backlink }}
             </a>
-          </VDescriptionItem>
-          <VDescriptionItem v-if="frozenFields.feedUrls?.length" label="RSS 地址">
+          </dd>
+        </div>
+        <div v-if="frozenFields.feedUrls?.length" class=":uno: flex gap-3 px-3.5 py-2.5 text-sm">
+          <dt class=":uno: w-18 shrink-0 text-gray-500">RSS 地址</dt>
+          <dd class=":uno: min-w-0 flex-1 text-gray-900 space-y-1">
             <div v-for="feedUrl in frozenFields.feedUrls" :key="feedUrl" class=":uno: break-all">
               {{ feedUrl }}
             </div>
-          </VDescriptionItem>
-        </VDescription>
-      </div>
+          </dd>
+        </div>
+      </dl>
     </div>
 
     <template #footer>

--- a/console/src/components/LinkApplicationOriginDetails.vue
+++ b/console/src/components/LinkApplicationOriginDetails.vue
@@ -4,7 +4,7 @@ import { useLinkApplicationOriginComment } from "@/composables/use-link-applicat
 import { htmlToPlainText } from "@/utils/comment-content";
 import { linkApplicationCommentRoute, linkApplicationSubjectMeta } from "@/utils/link-application-origin";
 import { linkApplicationOriginCommentErrorState } from "@/utils/link-application-review";
-import { IconExternalLinkLine, VDescription, VDescriptionItem } from "@halo-dev/components";
+import { IconExternalLinkLine } from "@halo-dev/components";
 import { utils } from "@halo-dev/ui-shared";
 import { computed } from "vue";
 
@@ -24,52 +24,42 @@ const commentContent = computed(() => htmlToPlainText(originComment.value?.raw |
 </script>
 
 <template>
-  <section v-if="origin.type === 'COMMENT'" class=":uno: border border-gray-200 rounded-lg bg-gray-50 p-3">
-    <h3 class=":uno: mb-3 text-sm text-gray-900 font-medium">评论识别信息</h3>
+  <section
+    v-if="origin.type === 'COMMENT'"
+    class=":uno: border border-gray-200 rounded-lg bg-gray-50/70 p-3.5 space-y-3"
+  >
+    <h3 class=":uno: text-sm text-gray-900 font-medium">评论识别信息</h3>
 
-    <div class=":uno: overflow-hidden border border-gray-100 rounded">
-      <VDescription>
-        <VDescriptionItem v-if="originComment" label="评论来源">
-          <a
-            v-if="subject?.url"
-            :href="subject.url"
-            target="_blank"
-            rel="noopener noreferrer"
-            class=":uno: inline-flex items-center gap-1 text-blue-600 hover:underline"
-          >
-            {{ subject.label }}
-            <IconExternalLinkLine class=":uno: h-3.5 w-3.5 shrink-0" />
-          </a>
-          <span v-else class=":uno: text-gray-500">来源页面不可用</span>
-        </VDescriptionItem>
+    <p v-if="isLoading" class=":uno: text-sm text-gray-500">正在加载评论...</p>
+    <p v-else-if="errorState === 'forbidden'" class=":uno: text-sm text-gray-500">当前账号没有查看来源评论的权限</p>
+    <p v-else-if="errorState === 'error'" class=":uno: text-sm text-gray-500">来源评论加载失败，请稍后重试</p>
+    <p v-else-if="!originComment" class=":uno: text-sm text-gray-500">原评论不可用（可能已被删除）</p>
 
-        <VDescriptionItem label="原评论">
-          <span v-if="isLoading" class=":uno: text-gray-500">正在加载评论...</span>
-          <template v-else-if="originComment">
-            <RouterLink v-if="commentRoute" :to="commentRoute" class=":uno: text-blue-600 hover:underline">
-              打开评论管理
-            </RouterLink>
-          </template>
-          <span v-else-if="errorState === 'forbidden'" class=":uno: text-gray-500">
-            当前账号没有查看来源评论的权限
-          </span>
-          <span v-else-if="errorState === 'error'" class=":uno: text-gray-500">来源评论加载失败，请稍后重试</span>
-          <span v-else class=":uno: text-gray-500">原评论不可用（可能已被删除）</span>
-        </VDescriptionItem>
+    <template v-else>
+      <blockquote
+        v-if="commentContent"
+        class=":uno: max-h-60 overflow-auto whitespace-pre-wrap break-words border-l-2 border-gray-300 pl-3 text-sm text-gray-700 leading-6"
+      >
+        {{ commentContent }}
+      </blockquote>
 
-        <VDescriptionItem v-if="commentContent" label="评论内容">
-          <pre
-            class=":uno: max-h-60 overflow-auto whitespace-pre-wrap break-words border border-gray-200 rounded bg-white p-3 text-xs text-gray-700"
-            >{{ commentContent }}</pre
-          >
-        </VDescriptionItem>
-
-        <VDescriptionItem
-          v-if="originComment?.creationTime"
-          label="评论时间"
-          :content="utils.date.format(originComment.creationTime)"
-        />
-      </VDescription>
-    </div>
+      <div class=":uno: flex flex-wrap items-center gap-x-4 gap-y-1.5 text-xs text-gray-500">
+        <a
+          v-if="subject?.url"
+          :href="subject.url"
+          target="_blank"
+          rel="noopener noreferrer"
+          class=":uno: inline-flex items-center gap-1 text-blue-600 hover:underline"
+        >
+          {{ subject.label }}
+          <IconExternalLinkLine class=":uno: h-3 w-3 shrink-0" />
+        </a>
+        <span v-else>来源页面不可用</span>
+        <span v-if="originComment.creationTime">评论于 {{ utils.date.format(originComment.creationTime) }}</span>
+        <RouterLink v-if="commentRoute" :to="commentRoute" class=":uno: text-blue-600 hover:underline">
+          打开评论管理
+        </RouterLink>
+      </div>
+    </template>
   </section>
 </template>


### PR DESCRIPTION
#### What this PR does / why we need it:

Refines the information display in the link application detail modal and review modal:

- Replaces the page-style `VDescription` blocks with a compact meta bar (status tag, source badge, contact email) at the top of the modal
- Reworks the frozen fields section (detail / resumable approval modes) into a compact definition list, so long URLs wrap properly instead of being squeezed into a narrow grid column
- Simplifies the comment origin section: removes the nested boxes, renders the comment content as a quote block, and folds source page, comment time, and the comment management entry into a single meta line
- Keeps loading, forbidden, error, and deleted-comment fallback states intact

The approval form itself is unchanged.

#### How to verify:

1. Start the dev environment with `./gradlew haloServer` and open the Console links page
2. Open a pending link application and check the compact info bar and comment origin section above the approval form
3. Open an approved / approving application and check the compact frozen fields list

Verified locally with type check, lint, and screenshots of all modal modes (pending, approving, approved, deleted-comment fallback).