### PR TITLE
Add link application notifications

### DIFF
--- a/openspec/changes/archive/2026-07-30-add-link-application-notifications/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-30-add-link-application-notifications/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-30

--- a/openspec/changes/archive/2026-07-30-add-link-application-notifications/design.md
+++ b/openspec/changes/archive/2026-07-30-add-link-application-notifications/design.md
@@ -1,0 +1,169 @@
+## Context
+
+Form submissions and Comment recognition both create applications through
+`LinkApplicationService.create`. The durable boundary is the successful
+`ReactiveExtensionClient.create` of a `PENDING` `LinkApplication`; invalid and duplicate
+submissions never cross that boundary.
+
+Halo notifications do not accept recipients directly on a Reason. A plugin declares a
+ReasonType and NotificationTemplate, maintains a Subscription for each intended Halo user, and
+emits a Reason whose recipients are resolved asynchronously from those subscriptions. The existing
+application settings already contain nested groups, and Halo exposes plugin configuration update
+events that can drive subscription reconciliation.
+
+The implementation must remain reactive on the application creation path, treat all submitted
+application fields as untrusted, preserve compatibility with settings saved before this change,
+and use the existing `/console/links` destination because applications do not have a routable
+Console detail view.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Let an administrator enable new-application notifications and select multiple Halo users.
+- Cover both form-origin and Comment-origin applications at their shared durable creation
+  boundary.
+- Use Halo's native notification resources, delivery channels, and per-user preferences.
+- Keep selected-user subscriptions aligned with settings across startup, updates, publication,
+  disablement, and plugin stop.
+- Isolate all notification failures from application creation.
+- Provide safe default Chinese plain-text and HTML notification content linked to
+  `/console/links`.
+
+**Non-Goals:**
+
+- Notify applicants when they submit, are approved, or are rejected.
+- Notify administrators about approval-state changes.
+- Backfill existing applications or observe LinkApplications created directly through the
+  Extension API.
+- Add a Console route, query deep link, custom recipient selector, digest, aggregation, frequency
+  limiting, English template, or strict exactly-once channel delivery.
+
+## Decisions
+
+### 1. Extend the application settings with a fail-closed notification subgroup
+
+Add `application.notification.enabled` and `application.notification.recipients`. The schema uses
+Halo's standard multi-user selector, labels the values as notification administrators, and requires
+at least one recipient while the notification switch is enabled. It does not implement a custom
+administrator filter.
+
+The settings DTO defaults to `enabled: false` and an empty recipient collection, trims and
+deduplicates usernames, and treats missing or unreadable values as disabled. Notification
+effectiveness requires the application master switch, the notification switch, and a non-empty
+recipient set. Disabling either switch preserves configured usernames but removes active
+subscriptions.
+
+This preserves old ConfigMaps without migration and avoids introducing notification delivery
+during an upgrade. A custom permission-aware selector was rejected because Halo permissions may
+come from different roles and change after selection.
+
+### 2. Publish only after the shared service durably creates an application
+
+Add a focused notification publisher invoked after `client.create(application)` succeeds inside
+`LinkApplicationService`. The publisher is part of the same reactive chain: it attempts
+subscription reconciliation and Reason creation before returning the created result, catches and
+logs notification errors, and always returns the already-created application.
+
+This covers FORM and COMMENT without duplicating logic and ensures INVALID and DUPLICATE results do
+not notify. A LinkApplication reconciler was rejected because observing arbitrary Extension writes
+would require durable notification idempotency and startup replay semantics that are outside the
+requested scope. Detached fire-and-forget publication was rejected because shutdown could silently
+lose an in-flight publication attempt.
+
+### 3. Use one native ReasonType and one default Chinese template
+
+Declare `plugin-links-new-link-application` as both the globally unique ReasonType and template
+resource name. The ReasonType is visible in personal notification preferences to users with
+`plugin:links:manage`.
+
+Each emitted Reason uses:
+
+- the system identity as author;
+- the concrete LinkApplication GVK and metadata name as subject identity;
+- the application display name as subject title;
+- an absolute `/console/links` management URL as subject URL and template data;
+- escaped display name, website URL, and localized origin label as template data.
+
+The default Chinese title is `收到新的友链申请：{网站名称}`. Plain-text and HTML bodies contain the
+website name, clickable website address, `访客自助申请` or `评论识别` source, and an `前往审核` action.
+The template must use escaped text bindings for all application-controlled values.
+
+Using native resources preserves Halo's standard station and external notifier behavior. Selected
+users may still disable this ReasonType or individual channels through their personal preferences;
+the plugin does not write Notifications directly or force email delivery.
+
+### 4. Treat settings as the source of truth for wildcard subscriptions
+
+For each valid selected username, maintain one Subscription for the notification ReasonType and a
+`LinkApplication` subject containing apiVersion and kind but no name. The wildcard subject lets a
+single per-user subscription match every concrete application Reason. The plugin owns subscriptions
+with this exact ReasonType and wildcard subject shape; reconciliation removes matching
+subscriptions for usernames no longer selected and idempotently subscribes the current set.
+
+All reconciliations use one process-local serialization boundary so setting updates and concurrent
+application creations cannot run competing unsubscribe/subscribe sequences. Reconciliation runs:
+
+1. when the plugin starts, to restore subscriptions from current settings;
+2. on `PluginConfigUpdatedEvent`, to apply setting changes promptly;
+3. immediately before each Reason emission, to recover from drift and use the latest readable
+   settings;
+4. with an empty effective recipient set when either switch is disabled;
+5. during plugin stop, to remove dynamic resources that Halo's declarative resource cleanup does
+   not own.
+
+Lifecycle callbacks may wait with a bounded timeout because Halo's start and stop contracts are
+synchronous; the application request path remains reactive. Historical Notifications are user
+data and are never deleted by this cleanup.
+
+Before subscribing, reconciliation checks that selected usernames still resolve to Halo users.
+Missing users are skipped, any stale matching subscription is removed, and a warning is logged
+without rewriting saved settings. The plugin deliberately does not re-check
+`plugin:links:manage`; a selected existing user continues receiving according to personal
+preferences until removed from settings, while Console authorization still guards the target page.
+
+### 5. Define delivery as best-effort without changing creation semantics
+
+For each effective successful creation, the plugin initiates one Reason emission. It does not add a
+plugin-level delivery retry, outbox, or per-application sent marker. Halo owns asynchronous
+recipient resolution, template rendering, channel retries, and user-level deduplication.
+
+Settings loading, user resolution, subscription, template registration, or Reason emission failure
+is logged and swallowed after the application has been persisted. This prevents a visitor from
+seeing a failed submission while a reviewable application already exists.
+
+Because Halo resolves recipients asynchronously, a settings change racing immediately after Reason
+creation may affect that one notification. Core reconciliation or notifier retries may also produce
+duplicate channel deliveries after partial failure. These limitations are accepted under the
+best-effort contract.
+
+## Risks / Trade-offs
+
+- [A selected user loses administrator permissions but continues receiving] → Keep notification
+  content minimal, rely on Console authorization, and clearly label the selector for
+  administrators.
+- [A deleted user remains in saved settings] → Remove any matching subscription, skip delivery,
+  log the stale username, and leave cleanup visible to the setting owner.
+- [Configuration and Reason processing race] → Serialize plugin reconciliation and re-check before
+  emission; document that Halo's later asynchronous resolution is still best-effort.
+- [Untrusted application content reaches an HTML notifier] → Use escaped template bindings only
+  and cover hostile values with a template smoke test.
+- [Lifecycle cleanup times out or fails] → Bound synchronous lifecycle waits, log failures, and
+  reconcile again on the next startup or publication.
+- [Halo retries after partial delivery] → Emit once from the plugin and avoid promising strict
+  exactly-once delivery.
+
+## Migration Plan
+
+1. Ship the disabled settings subgroup and declarative notification resources.
+2. On first startup, normalize missing notification settings to disabled and reconcile to an empty
+   subscription set.
+3. When an administrator enables notifications and saves recipients, reconcile subscriptions
+   immediately; only later successful applications notify.
+4. On rollback or plugin stop, remove plugin-owned dynamic subscriptions. Existing application
+   data, saved recipient values, and historical Notifications remain safe; older plugin versions
+   ignore the additional setting fields.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-07-30-add-link-application-notifications/proposal.md
+++ b/openspec/changes/archive/2026-07-30-add-link-application-notifications/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+New friend-link applications currently enter the review queue without notifying anyone, so
+administrators must discover them by revisiting the Links Console page. The plugin should use
+Halo's notification system to alert explicitly selected administrators whenever a new application
+is successfully created.
+
+## What Changes
+
+- Add a disabled-by-default notification subgroup to the existing friend-link application
+  settings, with an enable switch and a required multi-user recipient selector.
+- Notify all selected recipients for newly created form-origin and Comment-origin applications.
+- Publish notifications through Halo's native ReasonType, NotificationTemplate, Subscription, and
+  Reason mechanisms while respecting each recipient's notification preferences.
+- Keep application creation successful when settings, subscription, or notification publication
+  fails, and never notify for invalid, duplicate, or historical applications.
+- Reconcile plugin-managed subscriptions when the plugin starts, settings change, and immediately
+  before publication, and remove them when notifications or the plugin are disabled.
+- Link notifications to `/console/links` without adding a new Console route or application detail
+  deep link.
+
+## Capabilities
+
+### New Capabilities
+
+- `link-application-notification`: Configure selected notification recipients and deliver
+  best-effort Halo notifications for newly persisted friend-link applications.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Backend: application settings DTO/fetching, the shared application creation flow, notification
+  publication and subscription lifecycle, plugin startup/stop handling, and tests.
+- Console settings: the declarative settings schema gains a nested notification group; no custom
+  Console component or generated API client change is required.
+- Plugin resources: add a ReasonType and a default Chinese NotificationTemplate.
+- Halo integration: use the notification APIs already provided by the minimum supported Halo
+  version; no new external dependency or public endpoint is introduced.

--- a/openspec/changes/archive/2026-07-30-add-link-application-notifications/specs/link-application-notification/spec.md
+++ b/openspec/changes/archive/2026-07-30-add-link-application-notifications/specs/link-application-notification/spec.md
@@ -1,0 +1,181 @@
+## ADDED Requirements
+
+### Requirement: Administrators can configure new-application notifications
+The system SHALL provide a notification subgroup inside the friend-link application settings with
+a disabled-by-default enable switch and a multi-user recipient selection.
+
+#### Scenario: Existing installation has no notification settings
+- **WHEN** the application settings do not contain a notification subgroup
+- **THEN** new-application notifications are treated as disabled
+- **AND** no notification Subscription or Reason is created
+
+#### Scenario: Administrator enables notifications
+- **WHEN** an administrator enables new-application notifications
+- **THEN** the settings form requires at least one selected Halo user
+- **AND** accepts multiple selected users
+
+#### Scenario: Recipient selection is not permission-filtered
+- **WHEN** an administrator opens the recipient selector
+- **THEN** the selector uses Halo's standard selectable users
+- **AND** the plugin identifies the field as administrators who should receive notifications
+- **AND** the plugin does not enforce a role or `plugin:links:manage` permission check
+
+#### Scenario: Application master switch is disabled
+- **WHEN** the friend-link application master switch is disabled
+- **THEN** new-application notifications are ineffective regardless of their child switch
+- **AND** the configured recipient values are preserved
+
+#### Scenario: Notification switch is disabled
+- **WHEN** the notification switch is disabled
+- **THEN** new applications do not create notification Reasons
+- **AND** the configured recipient values are preserved
+
+#### Scenario: Notification settings cannot be loaded
+- **WHEN** notification settings are missing, malformed, or fail to load
+- **THEN** notification delivery is treated as disabled
+- **AND** application creation remains available according to the existing application settings
+
+### Requirement: Newly persisted applications initiate notifications
+The system SHALL attempt one native Halo Reason emission after each new friend-link application is
+successfully persisted as `PENDING` while notifications are effective.
+
+#### Scenario: Visitor form creates an application
+- **WHEN** a visitor form submission successfully creates a new FORM-origin `PENDING`
+  LinkApplication
+- **AND** notifications are effective
+- **THEN** the system attempts one new-application Reason emission
+
+#### Scenario: Comment recognition creates an application
+- **WHEN** Comment recognition successfully creates a new COMMENT-origin `PENDING`
+  LinkApplication
+- **AND** notifications are effective
+- **THEN** the system attempts one new-application Reason emission
+
+#### Scenario: Submission is invalid or duplicate
+- **WHEN** application creation returns INVALID or DUPLICATE
+- **THEN** the system does not create a new-application Reason
+
+#### Scenario: Notifications are enabled after pending applications already exist
+- **WHEN** an administrator enables notifications while existing applications are already present
+- **THEN** the system does not backfill Reasons for those existing applications
+
+#### Scenario: Application is created outside the shared service
+- **WHEN** a LinkApplication is written directly through the Extension API without using the
+  plugin's shared application creation service
+- **THEN** this capability does not guarantee a notification for that application
+
+### Requirement: Selected users receive native Halo notifications
+The system SHALL use Halo's Subscription, ReasonType, NotificationTemplate, and Reason mechanisms
+to notify each distinct, existing selected user according to that user's Halo notification
+preferences.
+
+#### Scenario: Multiple valid recipients are selected
+- **WHEN** notifications are effective for a newly persisted application
+- **AND** multiple distinct selected usernames resolve to Halo users
+- **THEN** each resolved user has one matching new-application Subscription
+- **AND** Halo resolves those users as recipients of the new-application Reason
+
+#### Scenario: Recipient list contains duplicate usernames
+- **WHEN** saved notification settings contain the same non-blank username more than once
+- **THEN** the system normalizes it to one effective recipient
+
+#### Scenario: Selected user no longer exists
+- **WHEN** a selected username does not resolve to a Halo user
+- **THEN** the system skips that username
+- **AND** removes any matching stale Subscription for it
+- **AND** continues processing other recipients
+- **AND** does not rewrite the saved recipient setting
+
+#### Scenario: Selected user loses link-management permission
+- **WHEN** a selected existing user no longer has `plugin:links:manage`
+- **THEN** the plugin continues to maintain that user's Subscription until the user is removed from
+  settings
+- **AND** Halo Console authorization independently controls access to `/console/links`
+
+#### Scenario: Selected user changes notification preferences
+- **WHEN** a selected user disables this ReasonType or an available notification channel in Halo
+- **THEN** delivery follows the user's Halo notification preferences
+- **AND** the plugin does not force a station notification or email
+
+### Requirement: Notification subscriptions follow configuration lifecycle
+The system SHALL treat the effective notification recipient set as the source of truth for
+plugin-managed wildcard LinkApplication Subscriptions.
+
+#### Scenario: Plugin starts with enabled notification settings
+- **WHEN** the plugin starts with notifications enabled and selected recipients
+- **THEN** the system reconciles matching Subscriptions from the current settings
+
+#### Scenario: Notification settings change
+- **WHEN** Halo publishes a plugin configuration update
+- **THEN** the system promptly reconciles added and removed recipients
+
+#### Scenario: Application is ready to publish a Reason
+- **WHEN** a newly persisted application is about to emit its Reason
+- **THEN** the system re-reads effective settings
+- **AND** serially reconciles matching Subscriptions before emission
+
+#### Scenario: Recipient is removed
+- **WHEN** a username is removed from the effective recipient set
+- **THEN** the system removes that user's matching new-application wildcard Subscription
+- **AND** later new applications no longer target that user
+
+#### Scenario: Notifications become ineffective
+- **WHEN** the application master switch or notification switch is disabled
+- **THEN** the system reconciles to no active new-application Subscriptions
+- **AND** preserves the configured recipient values
+
+#### Scenario: Plugin stops
+- **WHEN** the plugin stops
+- **THEN** the system removes its dynamic new-application Subscriptions
+- **AND** does not delete previously created Notifications
+
+### Requirement: Notifications contain minimal safe review context
+The system SHALL provide a default Chinese notification template with escaped plain-text and HTML
+content that identifies the application and links to the existing Links Console page.
+
+#### Scenario: Form-origin notification is rendered
+- **WHEN** a notification is rendered for a FORM-origin application
+- **THEN** its title is `收到新的友链申请：{网站名称}`
+- **AND** its body contains the escaped website name and website address
+- **AND** labels the source as `访客自助申请`
+- **AND** provides an `前往审核` action targeting `/console/links`
+
+#### Scenario: Comment-origin notification is rendered
+- **WHEN** a notification is rendered for a COMMENT-origin application
+- **THEN** its body labels the source as `评论识别`
+- **AND** does not include the source Comment metadata name or raw Comment content
+
+#### Scenario: Application contains hostile display text
+- **WHEN** an application-controlled value contains HTML or executable markup
+- **THEN** the HTML template renders that value as escaped text
+- **AND** does not interpret it as template or markup content
+
+#### Scenario: Notification content is inspected
+- **WHEN** a recipient reads the notification
+- **THEN** it does not expose the applicant email, description, raw Comment, or internal resource
+  metadata name
+
+#### Scenario: Recipient opens the review action
+- **WHEN** a recipient activates the notification review action
+- **THEN** the recipient is taken to `/console/links`
+- **AND** the plugin does not attempt to open a specific application detail view
+
+### Requirement: Notification failures do not change application creation
+The system SHALL isolate settings, subscription, and Reason publication failures from an
+application that has already been persisted.
+
+#### Scenario: Subscription reconciliation fails
+- **WHEN** Subscription reconciliation fails after a new application is persisted
+- **THEN** the system logs the failure
+- **AND** returns the application creation result as CREATED
+
+#### Scenario: Reason emission fails
+- **WHEN** Reason emission fails after a new application is persisted
+- **THEN** the system logs the failure
+- **AND** returns the application creation result as CREATED
+- **AND** does not delete or roll back the LinkApplication
+
+#### Scenario: Halo retries notification processing
+- **WHEN** Halo retries Reason reconciliation or an external notifier after a partial failure
+- **THEN** the plugin does not promise strict exactly-once channel delivery
+- **AND** the plugin does not initiate an additional emission for the same successful create call

--- a/openspec/changes/archive/2026-07-30-add-link-application-notifications/tasks.md
+++ b/openspec/changes/archive/2026-07-30-add-link-application-notifications/tasks.md
@@ -1,0 +1,53 @@
+## 1. Notification Settings
+
+- [x] 1.1 Add settings tests for disabled defaults, legacy configurations, recipient trimming and
+  deduplication, master-switch dependency, and enabled-without-recipients fail-closed behavior.
+- [x] 1.2 Extend `LinkApplicationSettings` with the normalized notification switch, recipient set,
+  and effective-state helpers required by the tests.
+- [x] 1.3 Add the nested notification group to `settings.yaml` using Halo's multi-user selector,
+  conditional required validation, administrator-focused labels, and preserved values while
+  disabled.
+
+## 2. Native Notification Resources
+
+- [x] 2.1 Add the `plugin-links-new-link-application` ReasonType and default Chinese
+  NotificationTemplate with `plugin:links:manage` UI permission, plain-text content, and escaped
+  HTML content.
+- [x] 2.2 Add a resource/template smoke test that locks required Reason attributes, FORM and
+  COMMENT source labels, the `/console/links` action, omitted private fields, and escaping of
+  hostile application values.
+
+## 3. Subscription Lifecycle
+
+- [x] 3.1 Add subscription manager tests for wildcard LinkApplication interest reasons,
+  username deduplication, missing-user filtering, added and removed recipients, disabled settings,
+  idempotent repeated reconciliation, and serialized concurrent reconciliation.
+- [x] 3.2 Implement the reactive subscription manager with the notification settings as its source
+  of truth and exact ReasonType plus wildcard LinkApplication subject matching.
+- [x] 3.3 Add lifecycle tests for startup restoration, `PluginConfigUpdatedEvent` reconciliation,
+  pre-publication reconciliation, bounded stop cleanup, and preservation of historical
+  Notifications.
+- [x] 3.4 Wire startup, configuration-update, and plugin-stop lifecycle hooks to the subscription
+  manager without blocking the application request path.
+
+## 4. Application Notification Publication
+
+- [x] 4.1 Add publisher tests for the system author, concrete LinkApplication subject, absolute
+  Console URL, minimal template attributes, distinct origin labels, disabled settings, and one
+  Reason emission per call.
+- [x] 4.2 Implement the reactive application notification publisher so it reconciles current
+  subscriptions before emitting `plugin-links-new-link-application`.
+- [x] 4.3 Extend `LinkApplicationService` tests to prove FORM and COMMENT durable creates notify,
+  INVALID and DUPLICATE results do not notify, and subscription or Reason failures still return
+  CREATED without deleting the application.
+- [x] 4.4 Invoke the publisher only after `ReactiveExtensionClient.create` succeeds in the shared
+  application service, with warning logs and error isolation around the notification stage.
+
+## 5. Verification
+
+- [x] 5.1 Run the targeted settings, subscription lifecycle, publisher, application service,
+  Router, and Comment recognition tests and fix only failures introduced by this change.
+- [x] 5.2 Run `./gradlew test` and `./gradlew build` to verify the complete backend and bundled
+  Console lifecycle.
+- [x] 5.3 Run `openspec validate add-link-application-notifications --strict` and confirm the
+  worktree contains only the intended implementation, tests, resources, and change artifacts.

--- a/openspec/specs/link-application-notification/spec.md
+++ b/openspec/specs/link-application-notification/spec.md
@@ -1,0 +1,187 @@
+# link-application-notification Specification
+
+## Purpose
+Define configurable native Halo notifications for newly persisted friend-link applications,
+including recipient subscriptions, lifecycle reconciliation, safe content, and failure isolation.
+
+## Requirements
+
+### Requirement: Administrators can configure new-application notifications
+The system SHALL provide a notification subgroup inside the friend-link application settings with
+a disabled-by-default enable switch and a multi-user recipient selection.
+
+#### Scenario: Existing installation has no notification settings
+- **WHEN** the application settings do not contain a notification subgroup
+- **THEN** new-application notifications are treated as disabled
+- **AND** no notification Subscription or Reason is created
+
+#### Scenario: Administrator enables notifications
+- **WHEN** an administrator enables new-application notifications
+- **THEN** the settings form requires at least one selected Halo user
+- **AND** accepts multiple selected users
+
+#### Scenario: Recipient selection is not permission-filtered
+- **WHEN** an administrator opens the recipient selector
+- **THEN** the selector uses Halo's standard selectable users
+- **AND** the plugin identifies the field as administrators who should receive notifications
+- **AND** the plugin does not enforce a role or `plugin:links:manage` permission check
+
+#### Scenario: Application master switch is disabled
+- **WHEN** the friend-link application master switch is disabled
+- **THEN** new-application notifications are ineffective regardless of their child switch
+- **AND** the configured recipient values are preserved
+
+#### Scenario: Notification switch is disabled
+- **WHEN** the notification switch is disabled
+- **THEN** new applications do not create notification Reasons
+- **AND** the configured recipient values are preserved
+
+#### Scenario: Notification settings cannot be loaded
+- **WHEN** notification settings are missing, malformed, or fail to load
+- **THEN** notification delivery is treated as disabled
+- **AND** application creation remains available according to the existing application settings
+
+### Requirement: Newly persisted applications initiate notifications
+The system SHALL attempt one native Halo Reason emission after each new friend-link application is
+successfully persisted as `PENDING` while notifications are effective.
+
+#### Scenario: Visitor form creates an application
+- **WHEN** a visitor form submission successfully creates a new FORM-origin `PENDING`
+  LinkApplication
+- **AND** notifications are effective
+- **THEN** the system attempts one new-application Reason emission
+
+#### Scenario: Comment recognition creates an application
+- **WHEN** Comment recognition successfully creates a new COMMENT-origin `PENDING`
+  LinkApplication
+- **AND** notifications are effective
+- **THEN** the system attempts one new-application Reason emission
+
+#### Scenario: Submission is invalid or duplicate
+- **WHEN** application creation returns INVALID or DUPLICATE
+- **THEN** the system does not create a new-application Reason
+
+#### Scenario: Notifications are enabled after pending applications already exist
+- **WHEN** an administrator enables notifications while existing applications are already present
+- **THEN** the system does not backfill Reasons for those existing applications
+
+#### Scenario: Application is created outside the shared service
+- **WHEN** a LinkApplication is written directly through the Extension API without using the
+  plugin's shared application creation service
+- **THEN** this capability does not guarantee a notification for that application
+
+### Requirement: Selected users receive native Halo notifications
+The system SHALL use Halo's Subscription, ReasonType, NotificationTemplate, and Reason mechanisms
+to notify each distinct, existing selected user according to that user's Halo notification
+preferences.
+
+#### Scenario: Multiple valid recipients are selected
+- **WHEN** notifications are effective for a newly persisted application
+- **AND** multiple distinct selected usernames resolve to Halo users
+- **THEN** each resolved user has one matching new-application Subscription
+- **AND** Halo resolves those users as recipients of the new-application Reason
+
+#### Scenario: Recipient list contains duplicate usernames
+- **WHEN** saved notification settings contain the same non-blank username more than once
+- **THEN** the system normalizes it to one effective recipient
+
+#### Scenario: Selected user no longer exists
+- **WHEN** a selected username does not resolve to a Halo user
+- **THEN** the system skips that username
+- **AND** removes any matching stale Subscription for it
+- **AND** continues processing other recipients
+- **AND** does not rewrite the saved recipient setting
+
+#### Scenario: Selected user loses link-management permission
+- **WHEN** a selected existing user no longer has `plugin:links:manage`
+- **THEN** the plugin continues to maintain that user's Subscription until the user is removed from
+  settings
+- **AND** Halo Console authorization independently controls access to `/console/links`
+
+#### Scenario: Selected user changes notification preferences
+- **WHEN** a selected user disables this ReasonType or an available notification channel in Halo
+- **THEN** delivery follows the user's Halo notification preferences
+- **AND** the plugin does not force a station notification or email
+
+### Requirement: Notification subscriptions follow configuration lifecycle
+The system SHALL treat the effective notification recipient set as the source of truth for
+plugin-managed wildcard LinkApplication Subscriptions.
+
+#### Scenario: Plugin starts with enabled notification settings
+- **WHEN** the plugin starts with notifications enabled and selected recipients
+- **THEN** the system reconciles matching Subscriptions from the current settings
+
+#### Scenario: Notification settings change
+- **WHEN** Halo publishes a plugin configuration update
+- **THEN** the system promptly reconciles added and removed recipients
+
+#### Scenario: Application is ready to publish a Reason
+- **WHEN** a newly persisted application is about to emit its Reason
+- **THEN** the system re-reads effective settings
+- **AND** serially reconciles matching Subscriptions before emission
+
+#### Scenario: Recipient is removed
+- **WHEN** a username is removed from the effective recipient set
+- **THEN** the system removes that user's matching new-application wildcard Subscription
+- **AND** later new applications no longer target that user
+
+#### Scenario: Notifications become ineffective
+- **WHEN** the application master switch or notification switch is disabled
+- **THEN** the system reconciles to no active new-application Subscriptions
+- **AND** preserves the configured recipient values
+
+#### Scenario: Plugin stops
+- **WHEN** the plugin stops
+- **THEN** the system removes its dynamic new-application Subscriptions
+- **AND** does not delete previously created Notifications
+
+### Requirement: Notifications contain minimal safe review context
+The system SHALL provide a default Chinese notification template with escaped plain-text and HTML
+content that identifies the application and links to the existing Links Console page.
+
+#### Scenario: Form-origin notification is rendered
+- **WHEN** a notification is rendered for a FORM-origin application
+- **THEN** its title is `收到新的友链申请：{网站名称}`
+- **AND** its body contains the escaped website name and website address
+- **AND** labels the source as `访客自助申请`
+- **AND** provides an `前往审核` action targeting `/console/links`
+
+#### Scenario: Comment-origin notification is rendered
+- **WHEN** a notification is rendered for a COMMENT-origin application
+- **THEN** its body labels the source as `评论识别`
+- **AND** does not include the source Comment metadata name or raw Comment content
+
+#### Scenario: Application contains hostile display text
+- **WHEN** an application-controlled value contains HTML or executable markup
+- **THEN** the HTML template renders that value as escaped text
+- **AND** does not interpret it as template or markup content
+
+#### Scenario: Notification content is inspected
+- **WHEN** a recipient reads the notification
+- **THEN** it does not expose the applicant email, description, raw Comment, or internal resource
+  metadata name
+
+#### Scenario: Recipient opens the review action
+- **WHEN** a recipient activates the notification review action
+- **THEN** the recipient is taken to `/console/links`
+- **AND** the plugin does not attempt to open a specific application detail view
+
+### Requirement: Notification failures do not change application creation
+The system SHALL isolate settings, subscription, and Reason publication failures from an
+application that has already been persisted.
+
+#### Scenario: Subscription reconciliation fails
+- **WHEN** Subscription reconciliation fails after a new application is persisted
+- **THEN** the system logs the failure
+- **AND** returns the application creation result as CREATED
+
+#### Scenario: Reason emission fails
+- **WHEN** Reason emission fails after a new application is persisted
+- **THEN** the system logs the failure
+- **AND** returns the application creation result as CREATED
+- **AND** does not delete or roll back the LinkApplication
+
+#### Scenario: Halo retries notification processing
+- **WHEN** Halo retries Reason reconciliation or an external notifier after a partial failure
+- **THEN** the plugin does not promise strict exactly-once channel delivery
+- **AND** the plugin does not initiate an additional emission for the same successful create call

--- a/src/main/java/run/halo/links/LinkPlugin.java
+++ b/src/main/java/run/halo/links/LinkPlugin.java
@@ -1,17 +1,21 @@
 package run.halo.links;
 
-import run.halo.app.extension.index.IndexSpecs;
-
+import java.time.Duration;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
 import run.halo.app.extension.Scheme;
 import run.halo.app.extension.SchemeManager;
+import run.halo.app.extension.index.IndexSpecs;
 import run.halo.app.plugin.BasePlugin;
 import run.halo.app.plugin.PluginContext;
 import run.halo.links.extension.Link;
 import run.halo.links.extension.LinkApplication;
 import run.halo.links.extension.LinkGroup;
+import run.halo.links.notification.LinkApplicationNotificationSubscriptionManager;
 
 /**
  * @author guqing
@@ -19,13 +23,31 @@ import run.halo.links.extension.LinkGroup;
  */
 @Component
 @EnableScheduling
+@Slf4j
 public class LinkPlugin extends BasePlugin {
+
+    private static final Duration NOTIFICATION_LIFECYCLE_TIMEOUT = Duration.ofSeconds(10);
 
     private final SchemeManager schemeManager;
 
-    public LinkPlugin(PluginContext pluginContext, SchemeManager schemeManager) {
+    private final LinkApplicationNotificationSubscriptionManager notificationSubscriptionManager;
+
+    private final Duration notificationLifecycleTimeout;
+
+    @Autowired
+    public LinkPlugin(PluginContext pluginContext, SchemeManager schemeManager,
+        LinkApplicationNotificationSubscriptionManager notificationSubscriptionManager) {
+        this(pluginContext, schemeManager, notificationSubscriptionManager,
+            NOTIFICATION_LIFECYCLE_TIMEOUT);
+    }
+
+    LinkPlugin(PluginContext pluginContext, SchemeManager schemeManager,
+        LinkApplicationNotificationSubscriptionManager notificationSubscriptionManager,
+        Duration notificationLifecycleTimeout) {
         super(pluginContext);
         this.schemeManager = schemeManager;
+        this.notificationSubscriptionManager = notificationSubscriptionManager;
+        this.notificationLifecycleTimeout = notificationLifecycleTimeout;
     }
 
     @Override
@@ -89,12 +111,28 @@ public class LinkPlugin extends BasePlugin {
                 })
             );
         });
+        runNotificationLifecycle(
+            notificationSubscriptionManager.reconcile().then(),
+            "restore notification subscriptions"
+        );
     }
 
     @Override
     public void stop() {
+        runNotificationLifecycle(
+            notificationSubscriptionManager.cleanup(),
+            "clean up notification subscriptions"
+        );
         schemeManager.unregister(Scheme.buildFromType(Link.class));
         schemeManager.unregister(Scheme.buildFromType(LinkGroup.class));
         schemeManager.unregister(Scheme.buildFromType(LinkApplication.class));
+    }
+
+    private void runNotificationLifecycle(Mono<Void> operation, String description) {
+        try {
+            operation.block(notificationLifecycleTimeout);
+        } catch (RuntimeException error) {
+            log.warn("[plugin-links] Failed to {}", description, error);
+        }
     }
 }

--- a/src/main/java/run/halo/links/dto/LinkApplicationSettings.java
+++ b/src/main/java/run/halo/links/dto/LinkApplicationSettings.java
@@ -2,6 +2,7 @@ package run.halo.links.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import lombok.Data;
@@ -16,11 +17,14 @@ public class LinkApplicationSettings {
 
     private CommentRecognition commentRecognition;
 
+    private Notification notification;
+
     public static LinkApplicationSettings defaults() {
         var settings = new LinkApplicationSettings();
         settings.setEnabled(false);
         settings.setSelfSubmission(SelfSubmission.defaults());
         settings.setCommentRecognition(CommentRecognition.defaults());
+        settings.setNotification(Notification.defaults());
         return settings;
     }
 
@@ -33,6 +37,9 @@ public class LinkApplicationSettings {
         settings.setCommentRecognition(commentRecognition == null
             ? CommentRecognition.defaults()
             : commentRecognition.normalized());
+        settings.setNotification(notification == null
+            ? Notification.defaults()
+            : notification.normalized());
         return settings;
     }
 
@@ -64,6 +71,19 @@ public class LinkApplicationSettings {
         return commentRecognition == null || commentRecognition.getSources() == null
             ? List.of()
             : commentRecognition.getSources();
+    }
+
+    public boolean notificationEnabled() {
+        return applicationEnabled()
+            && notification != null
+            && notification.enabled()
+            && !notificationRecipients().isEmpty();
+    }
+
+    public List<String> notificationRecipients() {
+        return notification == null || notification.getRecipients() == null
+            ? List.of()
+            : notification.getRecipients();
     }
 
     @Data
@@ -118,6 +138,32 @@ public class LinkApplicationSettings {
     }
 
     @Data
+    public static class Notification {
+
+        private Boolean enabled;
+
+        private List<String> recipients;
+
+        static Notification defaults() {
+            var settings = new Notification();
+            settings.setEnabled(false);
+            settings.setRecipients(List.of());
+            return settings;
+        }
+
+        Notification normalized() {
+            var settings = new Notification();
+            settings.setEnabled(Boolean.TRUE.equals(enabled));
+            settings.setRecipients(normalizeRecipients(recipients));
+            return settings;
+        }
+
+        boolean enabled() {
+            return Boolean.TRUE.equals(enabled);
+        }
+    }
+
+    @Data
     @Schema(description = "A Comment subject eligible for application recognition.")
     public static class RecognitionSource {
 
@@ -153,6 +199,20 @@ public class LinkApplicationSettings {
                 normalizedSource);
         }
         return List.copyOf(normalized.values());
+    }
+
+    private static List<String> normalizeRecipients(List<String> recipients) {
+        if (recipients == null || recipients.isEmpty()) {
+            return List.of();
+        }
+        var normalized = new LinkedHashSet<String>();
+        for (var recipient : recipients) {
+            var username = normalizeText(recipient);
+            if (username != null) {
+                normalized.add(username);
+            }
+        }
+        return List.copyOf(normalized);
     }
 
     private static String normalizeText(String value) {

--- a/src/main/java/run/halo/links/notification/LinkApplicationNotificationConfigListener.java
+++ b/src/main/java/run/halo/links/notification/LinkApplicationNotificationConfigListener.java
@@ -1,0 +1,30 @@
+package run.halo.links.notification;
+
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import run.halo.app.plugin.PluginConfigUpdatedEvent;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LinkApplicationNotificationConfigListener {
+
+    private static final Duration RECONCILIATION_TIMEOUT = Duration.ofSeconds(10);
+
+    private final LinkApplicationNotificationSubscriptionManager subscriptionManager;
+
+    @Async
+    @EventListener(PluginConfigUpdatedEvent.class)
+    public void onConfigUpdated(PluginConfigUpdatedEvent event) {
+        try {
+            subscriptionManager.reconcile().block(RECONCILIATION_TIMEOUT);
+        } catch (RuntimeException error) {
+            log.warn("[plugin-links] Failed to reconcile notification subscriptions after "
+                + "settings update", error);
+        }
+    }
+}

--- a/src/main/java/run/halo/links/notification/LinkApplicationNotificationPublisher.java
+++ b/src/main/java/run/halo/links/notification/LinkApplicationNotificationPublisher.java
@@ -1,0 +1,61 @@
+package run.halo.links.notification;
+
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+import run.halo.app.core.extension.notification.Reason;
+import run.halo.app.infra.ExternalLinkProcessor;
+import run.halo.app.notification.NotificationReasonEmitter;
+import run.halo.app.notification.UserIdentity;
+import run.halo.links.extension.LinkApplication;
+
+@Component
+@RequiredArgsConstructor
+public class LinkApplicationNotificationPublisher {
+
+    private static final String MANAGE_PATH = "/console/links";
+
+    private final LinkApplicationNotificationSubscriptionManager subscriptionManager;
+
+    private final NotificationReasonEmitter reasonEmitter;
+
+    private final ExternalLinkProcessor externalLinkProcessor;
+
+    public Mono<Void> publish(LinkApplication application) {
+        return subscriptionManager.reconcile()
+            .flatMap(enabled -> {
+                if (!enabled) {
+                    return Mono.empty();
+                }
+                String manageUrl = externalLinkProcessor.processLink(MANAGE_PATH);
+                var subject = Reason.Subject.builder()
+                    .apiVersion(application.getApiVersion())
+                    .kind(application.getKind())
+                    .name(application.getMetadata().getName())
+                    .title(application.getSpec().getDisplayName())
+                    .url(manageUrl)
+                    .build();
+                var attributes = Map.<String, Object>of(
+                    "displayName", application.getSpec().getDisplayName(),
+                    "websiteUrl", application.getSpec().getUrl(),
+                    "originLabel", originLabel(application.getSpec().getOrigin().getType()),
+                    "manageUrl", manageUrl
+                );
+                return reasonEmitter.emit(
+                    LinkApplicationNotificationSubscriptionManager.REASON_TYPE,
+                    builder -> builder
+                        .author(UserIdentity.of("system"))
+                        .subject(subject)
+                        .attributes(attributes)
+                );
+            });
+    }
+
+    private static String originLabel(LinkApplication.OriginType originType) {
+        return switch (originType) {
+            case FORM -> "访客自助申请";
+            case COMMENT -> "评论识别";
+        };
+    }
+}

--- a/src/main/java/run/halo/links/notification/LinkApplicationNotificationSubscriptionManager.java
+++ b/src/main/java/run/halo/links/notification/LinkApplicationNotificationSubscriptionManager.java
@@ -2,6 +2,7 @@ package run.halo.links.notification;
 
 import static run.halo.app.extension.index.query.Queries.equal;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -97,7 +98,7 @@ public class LinkApplicationNotificationSubscriptionManager {
         var subscriptionsByUser = new LinkedHashMap<String, List<Subscription>>();
         for (var subscription : existing) {
             String username = subscription.getSpec().getSubscriber().getName();
-            subscriptionsByUser.computeIfAbsent(username, ignored -> new java.util.ArrayList<>())
+            subscriptionsByUser.computeIfAbsent(username, ignored -> new ArrayList<>())
                 .add(subscription);
         }
 

--- a/src/main/java/run/halo/links/notification/LinkApplicationNotificationSubscriptionManager.java
+++ b/src/main/java/run/halo/links/notification/LinkApplicationNotificationSubscriptionManager.java
@@ -1,0 +1,165 @@
+package run.halo.links.notification;
+
+import static run.halo.app.extension.index.query.Queries.equal;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import run.halo.app.core.extension.User;
+import run.halo.app.core.extension.notification.Subscription;
+import run.halo.app.extension.ExtensionUtil;
+import run.halo.app.extension.GroupVersionKind;
+import run.halo.app.extension.ListOptions;
+import run.halo.app.extension.ReactiveExtensionClient;
+import run.halo.app.notification.NotificationCenter;
+import run.halo.links.endpoint.LinkApplicationSettingsFetcher;
+import run.halo.links.extension.LinkApplication;
+import run.halo.links.service.LinkApplicationCreationCoordinator;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LinkApplicationNotificationSubscriptionManager {
+
+    static final String REASON_TYPE = "plugin-links-new-link-application";
+
+    private static final String COORDINATION_KEY =
+        LinkApplicationNotificationSubscriptionManager.class.getName();
+
+    private static final GroupVersionKind APPLICATION_GVK =
+        GroupVersionKind.fromExtension(LinkApplication.class);
+
+    private final ReactiveExtensionClient client;
+
+    private final NotificationCenter notificationCenter;
+
+    private final LinkApplicationSettingsFetcher settingsFetcher;
+
+    private final LinkApplicationCreationCoordinator coordinator;
+
+    public Mono<Boolean> reconcile() {
+        return Mono.defer(() -> settingsFetcher.fetch()
+            .flatMap(settings -> {
+                boolean enabled = settings.notificationEnabled();
+                var recipients = enabled ? settings.notificationRecipients() : List.<String>of();
+                return coordinator.coordinate(COORDINATION_KEY,
+                    () -> reconcileRecipients(recipients).thenReturn(enabled));
+            }));
+    }
+
+    public Mono<Void> cleanup() {
+        return coordinator.coordinate(COORDINATION_KEY,
+            () -> reconcileRecipients(List.of()));
+    }
+
+    private Mono<Void> reconcileRecipients(List<String> recipients) {
+        var current = listManagedSubscriptions();
+        var validRecipients = resolveExistingUsers(recipients);
+        return Mono.zip(current, validRecipients)
+            .flatMap(existingAndDesired -> applyDiff(
+                existingAndDesired.getT1(), existingAndDesired.getT2()));
+    }
+
+    private Mono<List<Subscription>> listManagedSubscriptions() {
+        var options = ListOptions.builder()
+            .andQuery(equal("spec.reason.reasonType", REASON_TYPE))
+            .build();
+        return client.listAll(Subscription.class, options, Sort.unsorted())
+            .filter(Predicate.not(ExtensionUtil::isDeleted))
+            .filter(LinkApplicationNotificationSubscriptionManager::isManaged)
+            .collectList();
+    }
+
+    private Mono<LinkedHashSet<String>> resolveExistingUsers(List<String> recipients) {
+        return Flux.fromIterable(recipients)
+            .concatMap(username -> client.fetch(User.class, username)
+                .filter(Predicate.not(ExtensionUtil::isDeleted))
+                .map(ignored -> username)
+                .switchIfEmpty(Mono.defer(() -> {
+                    log.warn("[plugin-links] Notification recipient user [{}] no longer exists",
+                        username);
+                    return Mono.empty();
+                })))
+            .collect(LinkedHashSet::new, LinkedHashSet::add);
+    }
+
+    private Mono<Void> applyDiff(List<Subscription> existing,
+        LinkedHashSet<String> desiredRecipients) {
+        var subscriptionsByUser = new LinkedHashMap<String, List<Subscription>>();
+        for (var subscription : existing) {
+            String username = subscription.getSpec().getSubscriber().getName();
+            subscriptionsByUser.computeIfAbsent(username, ignored -> new java.util.ArrayList<>())
+                .add(subscription);
+        }
+
+        var removals = subscriptionsByUser.keySet().stream()
+            .filter(username -> !desiredRecipients.contains(username))
+            .toList();
+        var additions = desiredRecipients.stream()
+            .filter(username -> !hasOneEnabledSubscription(subscriptionsByUser.get(username)))
+            .toList();
+
+        return Flux.concat(
+                Flux.fromIterable(removals).concatMap(this::unsubscribe),
+                Flux.fromIterable(additions).concatMap(this::subscribe)
+            )
+            .then();
+    }
+
+    private Mono<Void> unsubscribe(String username) {
+        return notificationCenter.unsubscribe(subscriber(username), interestReason());
+    }
+
+    private Mono<Subscription> subscribe(String username) {
+        return notificationCenter.subscribe(subscriber(username), interestReason());
+    }
+
+    private static boolean hasOneEnabledSubscription(List<Subscription> subscriptions) {
+        return subscriptions != null
+            && subscriptions.size() == 1
+            && !subscriptions.getFirst().getSpec().isDisabled();
+    }
+
+    private static boolean isManaged(Subscription subscription) {
+        if (subscription == null || subscription.getSpec() == null
+            || subscription.getSpec().getSubscriber() == null
+            || StringUtils.isBlank(subscription.getSpec().getSubscriber().getName())) {
+            return false;
+        }
+        var reason = subscription.getSpec().getReason();
+        if (reason == null || !Objects.equals(REASON_TYPE, reason.getReasonType())
+            || StringUtils.isNotBlank(reason.getExpression())) {
+            return false;
+        }
+        var subject = reason.getSubject();
+        return subject != null
+            && Objects.equals(APPLICATION_GVK.groupVersion().toString(), subject.getApiVersion())
+            && Objects.equals(APPLICATION_GVK.kind(), subject.getKind())
+            && StringUtils.isBlank(subject.getName());
+    }
+
+    static Subscription.InterestReason interestReason() {
+        var reason = new Subscription.InterestReason();
+        reason.setReasonType(REASON_TYPE);
+        reason.setSubject(Subscription.ReasonSubject.builder()
+            .apiVersion(APPLICATION_GVK.groupVersion().toString())
+            .kind(APPLICATION_GVK.kind())
+            .build());
+        return reason;
+    }
+
+    private static Subscription.Subscriber subscriber(String username) {
+        var subscriber = new Subscription.Subscriber();
+        subscriber.setName(username);
+        return subscriber;
+    }
+}

--- a/src/main/java/run/halo/links/service/LinkApplicationService.java
+++ b/src/main/java/run/halo/links/service/LinkApplicationService.java
@@ -2,6 +2,7 @@ package run.halo.links.service;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Component;
@@ -11,16 +12,20 @@ import run.halo.app.extension.Metadata;
 import run.halo.app.extension.ReactiveExtensionClient;
 import run.halo.links.extension.Link;
 import run.halo.links.extension.LinkApplication;
+import run.halo.links.notification.LinkApplicationNotificationPublisher;
 
 /**
  * Shared validation, duplicate detection, and creation for link applications.
  */
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class LinkApplicationService {
 
     private final ReactiveExtensionClient client;
     private final LinkApplicationCreationCoordinator creationCoordinator;
+
+    private final LinkApplicationNotificationPublisher notificationPublisher;
 
     public Mono<CreateResult> create(Submission submission) {
         var validation = validate(submission);
@@ -45,6 +50,12 @@ public class LinkApplicationService {
                 }
                 var application = toApplication(submission);
                 return client.create(application)
+                    .flatMap(created -> notificationPublisher.publish(created)
+                        .doOnError(error -> log.warn(
+                            "[plugin-links] Failed to publish notification for application [{}]",
+                            created.getMetadata().getName(), error))
+                        .onErrorResume(error -> Mono.empty())
+                        .thenReturn(created))
                     .map(CreateResult::created);
             });
     }

--- a/src/main/resources/extensions/link-application-notification.yaml
+++ b/src/main/resources/extensions/link-application-notification.yaml
@@ -1,0 +1,72 @@
+apiVersion: notification.halo.run/v1alpha1
+kind: ReasonType
+metadata:
+  name: plugin-links-new-link-application
+  annotations:
+    rbac.authorization.halo.run/ui-permissions: |
+      ["plugin:links:manage"]
+spec:
+  displayName: "新的友链申请"
+  description: "所选管理员会在新的友链申请创建成功后收到通知。"
+  properties:
+    - name: displayName
+      type: string
+      description: "The submitted website display name."
+    - name: websiteUrl
+      type: string
+      description: "The submitted website URL."
+    - name: originLabel
+      type: string
+      description: "The localized application origin: 访客自助申请 or 评论识别."
+    - name: manageUrl
+      type: string
+      description: "The absolute URL of the Links Console page."
+---
+apiVersion: notification.halo.run/v1alpha1
+kind: NotificationTemplate
+metadata:
+  name: plugin-links-new-link-application
+spec:
+  reasonSelector:
+    reasonType: plugin-links-new-link-application
+    language: default
+  template:
+    title: "收到新的友链申请：[(${displayName})]"
+    rawBody: |
+      [(${subscriber.displayName})] 你好：
+
+        收到新的友链申请：[(${displayName})]
+        网站地址：[(${websiteUrl})]
+        申请来源：[(${originLabel})]
+
+        前往审核：[(${manageUrl})]
+    htmlBody: |
+      <div class="notification-content">
+        <div class="head">
+          <p th:text="|${subscriber.displayName} 你好：|"></p>
+        </div>
+        <div class="body">
+          <p>
+            收到新的友链申请：
+            <span th:text="${displayName}"></span>
+          </p>
+          <ul>
+            <li>
+              网站地址：
+              <a
+                th:href="${websiteUrl}"
+                th:text="${websiteUrl}"
+                target="_blank"
+                rel="noopener noreferrer"
+              ></a>
+            </li>
+            <li>
+              申请来源：
+              <span th:text="${originLabel}"></span>
+            </li>
+          </ul>
+          <p>
+            <a th:href="${manageUrl}">前往审核</a>
+          </p>
+        </div>
+      </div>

--- a/src/main/resources/extensions/settings.yaml
+++ b/src/main/resources/extensions/settings.yaml
@@ -154,7 +154,9 @@ spec:
               value: []
               multiple: true
               validation: required
-              help: 请选择拥有链接管理权限的管理员，插件不会自动校验所选用户的权限
+              help: >-
+                请选择拥有链接管理权限的管理员，插件不会自动校验权限。插件会按此列表维护通知订阅；
+                邮件中的取消订阅不会修改此列表，如需停止接收，请移除用户或由用户在个人通知偏好中关闭此类型。
     - group: ai
       label: AI
       formSchema:

--- a/src/main/resources/extensions/settings.yaml
+++ b/src/main/resources/extensions/settings.yaml
@@ -136,6 +136,25 @@ spec:
                   label: 页面
                   validation: required
                   clearable: false
+        - $formkit: group
+          if: "$get(link_application_enabled).value === true"
+          name: notification
+          label: 申请通知
+          children:
+            - $formkit: checkbox
+              label: 开启通知
+              name: enabled
+              id: link_application_notification_enabled
+              value: false
+              help: 新的友链申请创建成功后，通过 Halo 通知机制提醒所选管理员
+            - $formkit: userSelect
+              if: "$get(link_application_notification_enabled).value === true"
+              name: recipients
+              label: 接收通知的管理员
+              value: []
+              multiple: true
+              validation: required
+              help: 请选择拥有链接管理权限的管理员，插件不会自动校验所选用户的权限
     - group: ai
       label: AI
       formSchema:

--- a/src/test/java/run/halo/links/LinkPluginNotificationLifecycleTest.java
+++ b/src/test/java/run/halo/links/LinkPluginNotificationLifecycleTest.java
@@ -1,0 +1,63 @@
+package run.halo.links;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import run.halo.app.extension.SchemeManager;
+import run.halo.app.plugin.PluginContext;
+import run.halo.links.notification.LinkApplicationNotificationSubscriptionManager;
+
+@ExtendWith(MockitoExtension.class)
+class LinkPluginNotificationLifecycleTest {
+
+    @Mock
+    PluginContext pluginContext;
+
+    @Mock
+    SchemeManager schemeManager;
+
+    @Mock
+    LinkApplicationNotificationSubscriptionManager subscriptionManager;
+
+    @Test
+    void shouldReconcileOnStartAndCleanupOnStop() {
+        when(subscriptionManager.reconcile()).thenReturn(Mono.just(true));
+        when(subscriptionManager.cleanup()).thenReturn(Mono.empty());
+        var plugin = new LinkPlugin(pluginContext, schemeManager, subscriptionManager);
+
+        plugin.start();
+        plugin.stop();
+
+        verify(subscriptionManager).reconcile();
+        verify(subscriptionManager).cleanup();
+    }
+
+    @Test
+    void shouldKeepLifecycleAvailableWhenNotificationCleanupFails() {
+        when(subscriptionManager.reconcile())
+            .thenReturn(Mono.error(new IllegalStateException("start failed")));
+        when(subscriptionManager.cleanup())
+            .thenReturn(Mono.error(new IllegalStateException("stop failed")));
+        var plugin = new LinkPlugin(pluginContext, schemeManager, subscriptionManager);
+
+        assertThatCode(plugin::start).doesNotThrowAnyException();
+        assertThatCode(plugin::stop).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldBoundNotificationCleanupWaitOnStop() {
+        when(subscriptionManager.cleanup()).thenReturn(Mono.never());
+        var plugin = new LinkPlugin(pluginContext, schemeManager, subscriptionManager,
+            Duration.ofMillis(10));
+
+        assertTimeoutPreemptively(Duration.ofSeconds(1), plugin::stop);
+    }
+}

--- a/src/test/java/run/halo/links/LinkPluginSchedulingTest.java
+++ b/src/test/java/run/halo/links/LinkPluginSchedulingTest.java
@@ -9,6 +9,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.scheduling.config.ScheduledTaskHolder;
 import run.halo.app.extension.SchemeManager;
 import run.halo.app.plugin.PluginContext;
+import run.halo.links.notification.LinkApplicationNotificationSubscriptionManager;
 
 class LinkPluginSchedulingTest {
 
@@ -17,6 +18,8 @@ class LinkPluginSchedulingTest {
         try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext()) {
             context.registerBean(PluginContext.class, () -> mock(PluginContext.class));
             context.registerBean(SchemeManager.class, () -> mock(SchemeManager.class));
+            context.registerBean(LinkApplicationNotificationSubscriptionManager.class,
+                () -> mock(LinkApplicationNotificationSubscriptionManager.class));
             context.register(LinkPlugin.class, TestScheduledBean.class);
             context.refresh();
 

--- a/src/test/java/run/halo/links/endpoint/LinkApplicationSettingsFetcherTest.java
+++ b/src/test/java/run/halo/links/endpoint/LinkApplicationSettingsFetcherTest.java
@@ -31,10 +31,70 @@ class LinkApplicationSettingsFetcherTest {
                 assertThat(settings.applicationEnabled()).isFalse();
                 assertThat(settings.selfSubmissionEnabled()).isFalse();
                 assertThat(settings.commentRecognitionEnabled()).isFalse();
+                assertThat(settings.notificationEnabled()).isFalse();
+                assertThat(settings.notificationRecipients()).isEmpty();
             })
             .verifyComplete();
         StepVerifier.create(fetcher.fetch())
             .assertNext(settings -> assertThat(settings.applicationEnabled()).isFalse())
+            .verifyComplete();
+    }
+
+    @Test
+    void shouldFailClosedForLegacyOrIncompleteNotificationSettings() {
+        var legacy = new LinkApplicationSettings();
+        legacy.setEnabled(true);
+        var withoutRecipients = new LinkApplicationSettings();
+        withoutRecipients.setEnabled(true);
+        var notification = new LinkApplicationSettings.Notification();
+        notification.setEnabled(true);
+        withoutRecipients.setNotification(notification);
+        when(settingFetcher.fetch(LinkApplicationSettingsFetcher.SETTING_GROUP,
+            LinkApplicationSettings.class))
+            .thenReturn(Mono.just(legacy), Mono.just(withoutRecipients));
+        var fetcher = new LinkApplicationSettingsFetcher(settingFetcher);
+
+        StepVerifier.create(fetcher.fetch())
+            .assertNext(settings -> {
+                assertThat(settings.applicationEnabled()).isTrue();
+                assertThat(settings.notificationEnabled()).isFalse();
+                assertThat(settings.notificationRecipients()).isEmpty();
+            })
+            .verifyComplete();
+        StepVerifier.create(fetcher.fetch())
+            .assertNext(settings -> {
+                assertThat(settings.notificationEnabled()).isFalse();
+                assertThat(settings.notificationRecipients()).isEmpty();
+            })
+            .verifyComplete();
+    }
+
+    @Test
+    void shouldNormalizeNotificationRecipientsAndApplyMasterSwitch() {
+        var raw = new LinkApplicationSettings();
+        raw.setEnabled(true);
+        var notification = new LinkApplicationSettings.Notification();
+        notification.setEnabled(true);
+        notification.setRecipients(List.of(" admin ", "", "admin", " reviewer "));
+        raw.setNotification(notification);
+        when(settingFetcher.fetch(LinkApplicationSettingsFetcher.SETTING_GROUP,
+            LinkApplicationSettings.class)).thenReturn(Mono.just(raw));
+
+        StepVerifier.create(new LinkApplicationSettingsFetcher(settingFetcher).fetch())
+            .assertNext(settings -> {
+                assertThat(settings.notificationEnabled()).isTrue();
+                assertThat(settings.notificationRecipients())
+                    .containsExactly("admin", "reviewer");
+            })
+            .verifyComplete();
+
+        raw.setEnabled(false);
+        StepVerifier.create(Mono.just(raw.normalized()))
+            .assertNext(settings -> {
+                assertThat(settings.notificationEnabled()).isFalse();
+                assertThat(settings.notificationRecipients())
+                    .containsExactly("admin", "reviewer");
+            })
             .verifyComplete();
     }
 

--- a/src/test/java/run/halo/links/notification/LinkApplicationNotificationConfigListenerTest.java
+++ b/src/test/java/run/halo/links/notification/LinkApplicationNotificationConfigListenerTest.java
@@ -1,0 +1,41 @@
+package run.halo.links.notification;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import run.halo.app.plugin.PluginConfigUpdatedEvent;
+
+@ExtendWith(MockitoExtension.class)
+class LinkApplicationNotificationConfigListenerTest {
+
+    @Mock
+    LinkApplicationNotificationSubscriptionManager subscriptionManager;
+
+    @Mock
+    PluginConfigUpdatedEvent event;
+
+    @Test
+    void shouldReconcileWhenPluginSettingsChange() {
+        when(subscriptionManager.reconcile()).thenReturn(Mono.just(true));
+        var listener = new LinkApplicationNotificationConfigListener(subscriptionManager);
+
+        listener.onConfigUpdated(event);
+
+        verify(subscriptionManager).reconcile();
+    }
+
+    @Test
+    void shouldIsolateReconciliationFailureFromSettingsUpdate() {
+        when(subscriptionManager.reconcile())
+            .thenReturn(Mono.error(new IllegalStateException("failed")));
+        var listener = new LinkApplicationNotificationConfigListener(subscriptionManager);
+
+        assertThatCode(() -> listener.onConfigUpdated(event)).doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/run/halo/links/notification/LinkApplicationNotificationPublisherTest.java
+++ b/src/test/java/run/halo/links/notification/LinkApplicationNotificationPublisherTest.java
@@ -1,0 +1,136 @@
+package run.halo.links.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
+import reactor.test.StepVerifier;
+import run.halo.app.core.extension.notification.Reason;
+import run.halo.app.extension.Metadata;
+import run.halo.app.infra.ExternalLinkProcessor;
+import run.halo.app.notification.NotificationReasonEmitter;
+import run.halo.app.notification.ReasonPayload;
+import run.halo.links.extension.LinkApplication;
+
+@ExtendWith(MockitoExtension.class)
+class LinkApplicationNotificationPublisherTest {
+
+    @Mock
+    LinkApplicationNotificationSubscriptionManager subscriptionManager;
+
+    @Mock
+    NotificationReasonEmitter reasonEmitter;
+
+    @Mock
+    ExternalLinkProcessor externalLinkProcessor;
+
+    LinkApplicationNotificationPublisher publisher;
+
+    @BeforeEach
+    void setUp() {
+        publisher = new LinkApplicationNotificationPublisher(subscriptionManager, reasonEmitter,
+            externalLinkProcessor);
+    }
+
+    @Test
+    void shouldNotEmitWhenNotificationsAreIneffective() {
+        when(subscriptionManager.reconcile()).thenReturn(Mono.just(false));
+
+        StepVerifier.create(publisher.publish(application(LinkApplication.OriginType.FORM)))
+            .verifyComplete();
+
+        verify(reasonEmitter, never()).emit(any(), any());
+    }
+
+    @Test
+    void shouldReconcileBeforeEmittingFormApplicationReason() {
+        var reconciliation = Sinks.<Boolean>one();
+        when(subscriptionManager.reconcile()).thenReturn(reconciliation.asMono());
+        when(externalLinkProcessor.processLink("/console/links"))
+            .thenReturn("https://example.test/console/links");
+        when(reasonEmitter.emit(any(), any())).thenReturn(Mono.empty());
+        var application = application(LinkApplication.OriginType.FORM);
+
+        StepVerifier.create(publisher.publish(application))
+            .then(() -> verify(reasonEmitter, never()).emit(any(), any()))
+            .then(() -> reconciliation.tryEmitValue(true))
+            .verifyComplete();
+
+        var payload = capturePayload();
+        assertThat(payload.getAuthor().name()).isEqualTo("system");
+        assertThat(payload.getSubject())
+            .extracting(Reason.Subject::getApiVersion, Reason.Subject::getKind,
+                Reason.Subject::getName, Reason.Subject::getTitle, Reason.Subject::getUrl)
+            .containsExactly("core.halo.run/v1alpha1", "LinkApplication", "link-app-1",
+                "Example Site", "https://example.test/console/links");
+        assertThat(payload.getAttributes())
+            .containsExactlyInAnyOrderEntriesOf(java.util.Map.of(
+                "displayName", "Example Site",
+                "websiteUrl", "https://friend.example",
+                "originLabel", "访客自助申请",
+                "manageUrl", "https://example.test/console/links"
+            ));
+    }
+
+    @Test
+    void shouldUseCommentOriginLabelAndEmitOnce() {
+        when(subscriptionManager.reconcile()).thenReturn(Mono.just(true));
+        when(externalLinkProcessor.processLink("/console/links"))
+            .thenReturn("https://example.test/console/links");
+        when(reasonEmitter.emit(any(), any())).thenReturn(Mono.empty());
+
+        StepVerifier.create(publisher.publish(application(LinkApplication.OriginType.COMMENT)))
+            .verifyComplete();
+
+        var payload = capturePayload();
+        assertThat(payload.getAttributes()).containsEntry("originLabel", "评论识别");
+        verify(reasonEmitter).emit(eq("plugin-links-new-link-application"), any());
+    }
+
+    @Test
+    void shouldPropagateReconciliationFailureToCaller() {
+        when(subscriptionManager.reconcile())
+            .thenReturn(Mono.error(new IllegalStateException("failed")));
+
+        StepVerifier.create(publisher.publish(application(LinkApplication.OriginType.FORM)))
+            .expectErrorMessage("failed")
+            .verify();
+    }
+
+    private ReasonPayload capturePayload() {
+        @SuppressWarnings("unchecked")
+        var consumer = ArgumentCaptor.forClass(Consumer.class);
+        verify(reasonEmitter).emit(eq("plugin-links-new-link-application"), consumer.capture());
+        var builder = ReasonPayload.builder();
+        consumer.getValue().accept(builder);
+        return builder.build();
+    }
+
+    private static LinkApplication application(LinkApplication.OriginType originType) {
+        var application = new LinkApplication();
+        var metadata = new Metadata();
+        metadata.setName("link-app-1");
+        application.setMetadata(metadata);
+        var spec = new LinkApplication.LinkApplicationSpec();
+        spec.setDisplayName("Example Site");
+        spec.setUrl("https://friend.example");
+        spec.setStatus(LinkApplication.Status.PENDING);
+        var origin = new LinkApplication.Origin();
+        origin.setType(originType);
+        spec.setOrigin(origin);
+        application.setSpec(spec);
+        return application;
+    }
+}

--- a/src/test/java/run/halo/links/notification/LinkApplicationNotificationPublisherTest.java
+++ b/src/test/java/run/halo/links/notification/LinkApplicationNotificationPublisherTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Map;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -76,7 +77,7 @@ class LinkApplicationNotificationPublisherTest {
             .containsExactly("core.halo.run/v1alpha1", "LinkApplication", "link-app-1",
                 "Example Site", "https://example.test/console/links");
         assertThat(payload.getAttributes())
-            .containsExactlyInAnyOrderEntriesOf(java.util.Map.of(
+            .containsExactlyInAnyOrderEntriesOf(Map.of(
                 "displayName", "Example Site",
                 "websiteUrl", "https://friend.example",
                 "originLabel", "访客自助申请",

--- a/src/test/java/run/halo/links/notification/LinkApplicationNotificationResourceTest.java
+++ b/src/test/java/run/halo/links/notification/LinkApplicationNotificationResourceTest.java
@@ -1,0 +1,45 @@
+package run.halo.links.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+class LinkApplicationNotificationResourceTest {
+
+    @Test
+    void shouldDeclareReasonTypeAndSafeDefaultTemplate() throws IOException {
+        String yaml;
+        try (var input =
+            getClass().getResourceAsStream("/extensions/link-application-notification.yaml")) {
+            assertThat(input).isNotNull();
+            yaml = new String(input.readAllBytes(), StandardCharsets.UTF_8);
+        }
+
+        assertThat(yaml)
+            .contains("kind: ReasonType")
+            .contains("name: plugin-links-new-link-application")
+            .contains("[\"plugin:links:manage\"]")
+            .contains("name: displayName")
+            .contains("name: websiteUrl")
+            .contains("name: originLabel")
+            .contains("name: manageUrl")
+            .contains("kind: NotificationTemplate")
+            .contains("reasonType: plugin-links-new-link-application")
+            .contains("language: default")
+            .contains("收到新的友链申请：[(${displayName})]")
+            .contains("访客自助申请")
+            .contains("评论识别")
+            .contains("前往审核")
+            .contains("th:text=\"${displayName}\"")
+            .contains("th:text=\"${websiteUrl}\"")
+            .contains("th:text=\"${originLabel}\"")
+            .contains("th:href=\"${manageUrl}\"")
+            .doesNotContain("th:utext")
+            .doesNotContain("${email}")
+            .doesNotContain("${description}")
+            .doesNotContain("${commentName}")
+            .doesNotContain("${applicationName}");
+    }
+}

--- a/src/test/java/run/halo/links/notification/LinkApplicationNotificationSubscriptionManagerTest.java
+++ b/src/test/java/run/halo/links/notification/LinkApplicationNotificationSubscriptionManagerTest.java
@@ -1,0 +1,219 @@
+package run.halo.links.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Sort;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+import run.halo.app.core.extension.User;
+import run.halo.app.core.extension.notification.Subscription;
+import run.halo.app.extension.ListOptions;
+import run.halo.app.extension.Metadata;
+import run.halo.app.extension.ReactiveExtensionClient;
+import run.halo.app.notification.NotificationCenter;
+import run.halo.links.dto.LinkApplicationSettings;
+import run.halo.links.endpoint.LinkApplicationSettingsFetcher;
+import run.halo.links.service.LinkApplicationCreationCoordinator;
+
+@ExtendWith(MockitoExtension.class)
+class LinkApplicationNotificationSubscriptionManagerTest {
+
+    @Mock
+    ReactiveExtensionClient client;
+
+    @Mock
+    NotificationCenter notificationCenter;
+
+    @Mock
+    LinkApplicationSettingsFetcher settingsFetcher;
+
+    LinkApplicationNotificationSubscriptionManager manager;
+
+    @BeforeEach
+    void setUp() {
+        manager = new LinkApplicationNotificationSubscriptionManager(client, notificationCenter,
+            settingsFetcher, new LinkApplicationCreationCoordinator());
+    }
+
+    @Test
+    void shouldReconcileAddedRemovedAndDuplicateSubscriptions() {
+        when(settingsFetcher.fetch()).thenReturn(Mono.just(settings(true,
+            List.of("admin", "reviewer"))));
+        when(client.listAll(eq(Subscription.class), any(ListOptions.class), any(Sort.class)))
+            .thenReturn(Flux.just(
+                subscription("admin"),
+                subscription("admin"),
+                subscription("removed")
+            ));
+        givenUser("admin", true);
+        givenUser("reviewer", true);
+        when(notificationCenter.unsubscribe(any(), any())).thenReturn(Mono.empty());
+        when(notificationCenter.subscribe(any(), any()))
+            .thenAnswer(invocation -> Mono.just(subscription(
+                invocation.<Subscription.Subscriber>getArgument(0).getName())));
+
+        StepVerifier.create(manager.reconcile())
+            .expectNext(true)
+            .verifyComplete();
+
+        var removedSubscriber = ArgumentCaptor.forClass(Subscription.Subscriber.class);
+        verify(notificationCenter).unsubscribe(removedSubscriber.capture(), any());
+        assertThat(removedSubscriber.getValue().getName()).isEqualTo("removed");
+        var addedSubscribers = ArgumentCaptor.forClass(Subscription.Subscriber.class);
+        var reasons = ArgumentCaptor.forClass(Subscription.InterestReason.class);
+        verify(notificationCenter, org.mockito.Mockito.times(2))
+            .subscribe(addedSubscribers.capture(), reasons.capture());
+        assertThat(addedSubscribers.getAllValues())
+            .extracting(Subscription.Subscriber::getName)
+            .containsExactlyInAnyOrder("admin", "reviewer");
+        assertThat(reasons.getAllValues()).allSatisfy(reason -> {
+            assertThat(reason.getReasonType())
+                .isEqualTo("plugin-links-new-link-application");
+            assertThat(reason.getExpression()).isNull();
+            assertThat(reason.getSubject().getApiVersion())
+                .isEqualTo("core.halo.run/v1alpha1");
+            assertThat(reason.getSubject().getKind()).isEqualTo("LinkApplication");
+            assertThat(reason.getSubject().getName()).isNull();
+        });
+    }
+
+    @Test
+    void shouldSkipMissingUsersAndRemoveTheirStaleSubscription() {
+        when(settingsFetcher.fetch()).thenReturn(Mono.just(settings(true,
+            List.of("missing", "reviewer"))));
+        when(client.listAll(eq(Subscription.class), any(ListOptions.class), any(Sort.class)))
+            .thenReturn(Flux.just(subscription("missing")));
+        givenUser("missing", false);
+        givenUser("reviewer", true);
+        when(notificationCenter.unsubscribe(any(), any())).thenReturn(Mono.empty());
+        when(notificationCenter.subscribe(any(), any()))
+            .thenReturn(Mono.just(subscription("reviewer")));
+
+        StepVerifier.create(manager.reconcile())
+            .expectNext(true)
+            .verifyComplete();
+
+        var removed = ArgumentCaptor.forClass(Subscription.Subscriber.class);
+        verify(notificationCenter).unsubscribe(removed.capture(), any());
+        assertThat(removed.getValue().getName()).isEqualTo("missing");
+        var added = ArgumentCaptor.forClass(Subscription.Subscriber.class);
+        verify(notificationCenter).subscribe(added.capture(), any());
+        assertThat(added.getValue().getName()).isEqualTo("reviewer");
+    }
+
+    @Test
+    void shouldCleanSubscriptionsWhenDisabledAndRemainIdempotentWhenAligned() {
+        when(settingsFetcher.fetch()).thenReturn(
+            Mono.just(settings(false, List.of("admin"))),
+            Mono.just(settings(true, List.of("admin")))
+        );
+        when(client.listAll(eq(Subscription.class), any(ListOptions.class), any(Sort.class)))
+            .thenReturn(Flux.just(subscription("admin")));
+        givenUser("admin", true);
+        when(notificationCenter.unsubscribe(any(), any())).thenReturn(Mono.empty());
+
+        StepVerifier.create(manager.reconcile())
+            .expectNext(false)
+            .verifyComplete();
+        StepVerifier.create(manager.reconcile())
+            .expectNext(true)
+            .verifyComplete();
+
+        verify(notificationCenter, org.mockito.Mockito.times(1)).unsubscribe(any(), any());
+        verify(notificationCenter, never()).subscribe(any(), any());
+    }
+
+    @Test
+    void shouldSerializeConcurrentReconciliation() {
+        when(settingsFetcher.fetch()).thenReturn(Mono.just(settings(true, List.of("admin"))));
+        when(client.listAll(eq(Subscription.class), any(ListOptions.class), any(Sort.class)))
+            .thenReturn(Flux.empty());
+        givenUser("admin", true);
+        var active = new AtomicInteger();
+        var maximumActive = new AtomicInteger();
+        when(notificationCenter.subscribe(any(), any())).thenAnswer(ignored -> Mono.defer(() -> {
+            int current = active.incrementAndGet();
+            maximumActive.accumulateAndGet(current, Math::max);
+            return Mono.delay(Duration.ofMillis(25))
+                .then(Mono.fromCallable(() -> {
+                    active.decrementAndGet();
+                    return subscription("admin");
+                }));
+        }));
+
+        StepVerifier.create(Flux.merge(manager.reconcile(), manager.reconcile()).collectList())
+            .assertNext(results -> assertThat(results).containsExactlyInAnyOrder(true, true))
+            .verifyComplete();
+
+        assertThat(maximumActive).hasValue(1);
+    }
+
+    @Test
+    void shouldCleanupOnlyManagedSubscriptions() {
+        when(client.listAll(eq(Subscription.class), any(ListOptions.class), any(Sort.class)))
+            .thenReturn(Flux.just(subscription("admin")));
+        when(notificationCenter.unsubscribe(any(), any())).thenReturn(Mono.empty());
+
+        StepVerifier.create(manager.cleanup()).verifyComplete();
+
+        verify(notificationCenter).unsubscribe(any(), any());
+        verify(client, never()).delete(any());
+    }
+
+    private void givenUser(String username, boolean exists) {
+        when(client.fetch(User.class, username))
+            .thenReturn(exists ? Mono.just(user(username)) : Mono.empty());
+    }
+
+    private static LinkApplicationSettings settings(boolean notificationEnabled,
+        List<String> recipients) {
+        var settings = new LinkApplicationSettings();
+        settings.setEnabled(true);
+        var notification = new LinkApplicationSettings.Notification();
+        notification.setEnabled(notificationEnabled);
+        notification.setRecipients(recipients);
+        settings.setNotification(notification);
+        return settings.normalized();
+    }
+
+    private static User user(String username) {
+        var user = new User();
+        var metadata = new Metadata();
+        metadata.setName(username);
+        user.setMetadata(metadata);
+        return user;
+    }
+
+    private static Subscription subscription(String username) {
+        var subscription = new Subscription();
+        subscription.setMetadata(new Metadata());
+        var spec = new Subscription.Spec();
+        var subscriber = new Subscription.Subscriber();
+        subscriber.setName(username);
+        spec.setSubscriber(subscriber);
+        var reason = new Subscription.InterestReason();
+        reason.setReasonType("plugin-links-new-link-application");
+        reason.setSubject(Subscription.ReasonSubject.builder()
+            .apiVersion("core.halo.run/v1alpha1")
+            .kind("LinkApplication")
+            .build());
+        spec.setReason(reason);
+        subscription.setSpec(spec);
+        return subscription;
+    }
+}

--- a/src/test/java/run/halo/links/notification/LinkApplicationNotificationSubscriptionManagerTest.java
+++ b/src/test/java/run/halo/links/notification/LinkApplicationNotificationSubscriptionManagerTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -76,7 +77,7 @@ class LinkApplicationNotificationSubscriptionManagerTest {
         assertThat(removedSubscriber.getValue().getName()).isEqualTo("removed");
         var addedSubscribers = ArgumentCaptor.forClass(Subscription.Subscriber.class);
         var reasons = ArgumentCaptor.forClass(Subscription.InterestReason.class);
-        verify(notificationCenter, org.mockito.Mockito.times(2))
+        verify(notificationCenter, times(2))
             .subscribe(addedSubscribers.capture(), reasons.capture());
         assertThat(addedSubscribers.getAllValues())
             .extracting(Subscription.Subscriber::getName)
@@ -134,7 +135,7 @@ class LinkApplicationNotificationSubscriptionManagerTest {
             .expectNext(true)
             .verifyComplete();
 
-        verify(notificationCenter, org.mockito.Mockito.times(1)).unsubscribe(any(), any());
+        verify(notificationCenter, times(1)).unsubscribe(any(), any());
         verify(notificationCenter, never()).subscribe(any(), any());
     }
 

--- a/src/test/java/run/halo/links/service/LinkApplicationServiceTest.java
+++ b/src/test/java/run/halo/links/service/LinkApplicationServiceTest.java
@@ -2,6 +2,9 @@ package run.halo.links.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -20,6 +23,7 @@ import run.halo.app.extension.Metadata;
 import run.halo.app.extension.ReactiveExtensionClient;
 import run.halo.links.extension.Link;
 import run.halo.links.extension.LinkApplication;
+import run.halo.links.notification.LinkApplicationNotificationPublisher;
 
 @ExtendWith(MockitoExtension.class)
 class LinkApplicationServiceTest {
@@ -27,12 +31,16 @@ class LinkApplicationServiceTest {
     @Mock
     ReactiveExtensionClient client;
 
+    @Mock
+    LinkApplicationNotificationPublisher notificationPublisher;
+
     LinkApplicationService service;
 
     @BeforeEach
     void setUp() {
+        lenient().when(notificationPublisher.publish(any())).thenReturn(Mono.empty());
         service = new LinkApplicationService(client,
-            new LinkApplicationCreationCoordinator());
+            new LinkApplicationCreationCoordinator(), notificationPublisher);
     }
 
     @Test
@@ -54,6 +62,7 @@ class LinkApplicationServiceTest {
                     .isEqualTo(LinkApplication.OriginType.FORM);
             })
             .verifyComplete();
+        verify(notificationPublisher).publish(any(LinkApplication.class));
     }
 
     @Test
@@ -66,6 +75,7 @@ class LinkApplicationServiceTest {
                 assertThat(result.field()).isEqualTo("url");
             })
             .verifyComplete();
+        verify(notificationPublisher, never()).publish(any());
     }
 
     @Test
@@ -198,6 +208,24 @@ class LinkApplicationServiceTest {
             .assertNext(result -> assertThat(result.application().getSpec().getOrigin()
                 .getComment().getName()).isEqualTo("comment-a"))
             .verifyComplete();
+        verify(notificationPublisher).publish(any(LinkApplication.class));
+    }
+
+    @Test
+    void shouldKeepCreatedResultWhenNotificationFails() {
+        givenExisting(List.of(), List.of());
+        when(client.create(any(LinkApplication.class)))
+            .thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+        when(notificationPublisher.publish(any()))
+            .thenReturn(Mono.error(new IllegalStateException("notification failed")));
+
+        StepVerifier.create(service.create(submission("https://example.com",
+                LinkApplication.OriginType.FORM, null)))
+            .assertNext(result -> assertThat(result.status())
+                .isEqualTo(LinkApplicationService.CreateStatus.CREATED))
+            .verifyComplete();
+
+        verify(notificationPublisher).publish(any(LinkApplication.class));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- add configurable Halo notifications for newly persisted link applications
- allow administrators to select multiple notification recipients in the plugin settings
- reconcile plugin-managed subscriptions on startup, configuration updates, publication, and shutdown
- publish notifications for form and comment-origin applications without affecting successful creation when notification processing fails
- add notification resources, lifecycle coverage, payload safety tests, and the archived OpenSpec specification

## Testing

- `./gradlew test`
- `./gradlew build`
- `openspec validate link-application-notification --type spec --strict`
- `git diff --check`