### PR TITLE
Add pending link application capacity

### DIFF
--- a/dev/theme-api.md
+++ b/dev/theme-api.md
@@ -88,6 +88,10 @@
 插件设置中的“友链申请”总开关默认关闭。总开关和“允许访客提交”子开关同时开启时，
 `linkApplicationEnabled` 为 `true`，主题才应展示申请入口。
 
+待审核申请达到管理员配置的容量时，`linkApplicationEnabled` 仍为 `true`，验证码图片
+端点也保持可用。容量可能随审核进度动态释放，主题无需读取或展示容量值，提交结果以
+`POST /links/apply` 的重定向为准。
+
 主题展示申请表单时，必须加载内置图形验证码，并随表单提交 `captchaCode`。
 
 验证码图片端点为同源的 `GET /links/captcha`。开启访客申请时，它返回固定
@@ -194,6 +198,12 @@ await fetch('/links/apply', {
 - 验证码缺失、格式错误、答案错误、过期或重放统一返回
   `applied=error&field=captchaCode&message=验证码错误或已过期，请重新输入`，且不会返回
   `value` 或其他已提交字段；主题应重新加载图片
+- 待审核申请达到容量：
+  `applied=error&message=待审核申请数量已达上限，请稍后再试`
+- 容量设置或待审核数量暂时无法读取：
+  `applied=error&message=暂时无法提交，请稍后再试`
+- 两种容量错误都不包含 `field`、`value` 或实际容量；已经验证的 CAPTCHA 和提交频率
+  额度仍会被消耗
 - 功能关闭：`applied=disabled&message=友链申请功能暂未开放`
 
 ---

--- a/openspec/changes/limit-pending-link-applications/.openspec.yaml
+++ b/openspec/changes/limit-pending-link-applications/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-30

--- a/openspec/changes/limit-pending-link-applications/design.md
+++ b/openspec/changes/limit-pending-link-applications/design.md
@@ -1,0 +1,203 @@
+## Context
+
+Visitor forms and Comment recognition are the two supported LinkApplication creation paths. Both
+eventually call `LinkApplicationService`, which validates input, lists existing Links and
+LinkApplications for source-aware duplicate detection, persists one `PENDING` application, and
+publishes a notification after successful persistence.
+
+Existing application creation is serialized by canonical URL within one plugin process. That
+prevents duplicate creation for the same URL, but two different URLs can concurrently observe 99
+pending applications and both create when the configured capacity is 100. Capacity therefore needs
+one additional process-wide creation boundary around the authoritative count-and-create operation.
+
+`spec.status` is indexed, and the existing history API already exposes a server-reported total for
+`PENDING`. Comment recognition runs only for newly delivered Comments, uses one worker, and does not
+backfill Comments missed while recognition is unavailable.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add a positive pending-review capacity setting with a backend and settings-schema default of 100.
+- Share one capacity across FORM and COMMENT origins while counting only `PENDING` applications.
+- Enforce a hard upper bound across supported creation paths and different URLs in one plugin
+  instance.
+- Preserve duplicate semantics, visitor security checks, existing theme availability, and
+  successful-creation notifications.
+- Avoid unnecessary Comment AI calls while full and fail closed when capacity cannot be evaluated.
+- Keep capacity rejection a normal, non-logging control flow.
+
+**Non-Goals:**
+
+- Cross-instance distributed coordination or a persisted capacity counter.
+- Admission control for privileged direct writes through Halo's generic Extension API.
+- Per-origin quotas, rate limits, automatic cleanup, or automatic rejection of existing
+  applications.
+- A Console capacity progress indicator, a new generated API, or a persisted LinkApplication field.
+- Compatibility branches, setting migration, data migration, or legacy-setting tests for the
+  unreleased application feature.
+
+## Decisions
+
+### 1. Add one required positive setting under Application Security
+
+Add `application.security.pendingCapacity` as a required number with minimum `1`, default `100`,
+and help text explaining that new applications pause while the pending count is at the limit. The
+Security subgroup follows the application master switch, like the other application child groups.
+
+`LinkApplicationSettings` owns the same default so behavior does not depend on whether the settings
+form has been saved. A missing value uses the feature default. An explicitly non-positive or
+otherwise malformed value makes application settings unavailable and preserves the current
+fail-closed behavior for new creation.
+
+There is no maximum value and `0` has no special meaning. Administrators use the existing master
+switch to stop all new applications.
+
+**Alternatives considered:**
+
+- Treating `0` as unlimited creates a dangerous typo path for a security control.
+- Treating `0` as disabled duplicates the existing master switch.
+- Adding a maximum prevents administrators from deliberately choosing a larger review queue
+  without improving enforcement.
+
+### 2. Define capacity as the current number of PENDING applications
+
+FORM and COMMENT origins use the same pool. Only `spec.status == PENDING` consumes capacity;
+`APPROVING`, `APPROVED`, and `REJECTED` do not. Approval reservation, rejection, or deletion of a
+pending application therefore releases capacity without maintaining a separate counter.
+
+Lowering the setting below the current count does not mutate existing resources. New creation
+remains blocked until the count becomes strictly less than the new value.
+
+The authoritative creation path reuses the LinkApplication list already required for duplicate
+detection. Duplicate detection runs before capacity evaluation, so an already-submitted URL keeps
+its existing duplicate result even while the queue is full.
+
+**Alternatives considered:**
+
+- Counting `APPROVING` conflates work already accepted by an administrator with the waiting review
+  backlog.
+- A persisted counter creates reconciliation, rollback, and crash-consistency work for data already
+  represented by indexed resources.
+- Automatically deleting or rejecting excess records would destroy administrator-owned review
+  data.
+
+### 3. Add a process-wide creation gate around authoritative enforcement
+
+All supported `LinkApplicationService.create` operations enter one process-wide asynchronous gate
+before the existing canonical-URL coordination and remain inside it through settings evaluation,
+duplicate detection, pending counting, persistence, and result production. The existing per-URL
+coordination remains because approval reservation also uses it to protect URL occupancy.
+
+The lock order is always process-wide creation gate followed by canonical-URL coordination.
+Approval does not acquire the creation gate and can only reduce the pending count, so it cannot
+cause an overflow or form a reverse lock cycle. The gate releases on success, rejection, or error
+and does not retain per-request keys.
+
+This guarantees that two different URLs competing for one remaining slot can produce at most one
+new application in one plugin instance. Direct Extension writes and other plugin instances remain
+outside the guarantee.
+
+**Alternatives considered:**
+
+- A count followed by create under only the URL-specific gate permits different URLs to exceed the
+  limit.
+- A database-style reservation resource or distributed lock expands the change beyond Halo's
+  current single-instance application-creation contract.
+- Replacing URL coordination entirely would weaken its existing interaction with approval
+  reservation.
+
+### 4. Represent full capacity as a normal creation result
+
+Add a distinct capacity-reached result to shared application creation. It does not persist an
+application and therefore never invokes the notification publisher. Settings or storage failures
+remain operational failures rather than being mislabeled as normal capacity exhaustion.
+
+Normal full-capacity results do not produce warning logs. Actual settings or pending-count failures
+fail closed and produce an operational error without application fields, URLs, Comment content, or
+other attacker-controlled values.
+
+**Alternatives considered:**
+
+- Mapping full capacity to INVALID loses the distinction between applicant input and server policy.
+- Throwing for normal fullness would create noisy failure diagnostics under intentional abuse.
+- Publishing a capacity notification provides attackers with a notification-spam mechanism.
+
+### 5. Preserve visitor security ordering and theme availability
+
+The effective visitor sequence remains:
+
+1. application and visitor-channel settings;
+2. form parsing and CAPTCHA consumption;
+3. the one-minute IP submission allowance;
+4. shared validation and duplicate detection;
+5. authoritative capacity evaluation;
+6. persistence and success notification.
+
+A full queue redirects to:
+
+`/links?applied=error&message=待审核申请数量已达上限，请稍后再试`
+
+The redirect includes neither `field`, `value`, nor the configured capacity. The valid CAPTCHA and
+IP allowance remain consumed, so fullness does not create a free high-frequency probing path.
+
+If authoritative capacity evaluation fails, the visitor receives:
+
+`/links?applied=error&message=暂时无法提交，请稍后再试`
+
+The template model continues to expose `linkApplicationEnabled` from the master and visitor
+switches only. `GET /links/captcha` also stays available while full because capacity can be released
+at any time and themes should not depend on a dynamic availability contract.
+
+### 6. Use a non-authoritative precheck to avoid unnecessary Comment AI calls
+
+Before invoking AI, Comment recognition reads the effective capacity and queries the indexed
+`PENDING` total. If the queue is full, or capacity cannot be evaluated, it skips model invocation
+and does not create an application.
+
+The precheck is only a cost optimization. After a positive model result, the shared service enters
+the global gate and repeats the authoritative evaluation. If another source consumes the last slot
+between the checks, the Comment produces a capacity-skipped outcome.
+
+Comments skipped before or after AI are not retried or backfilled. This preserves the current
+new-Comment-only lifecycle and prevents a later capacity release from triggering a burst of old
+model calls.
+
+**Alternatives considered:**
+
+- Checking only after AI enforces storage capacity but wastes model calls while the queue is known
+  to be full.
+- Relying only on the precheck is race-prone and cannot enforce a hard upper bound.
+- Queueing skipped Comments introduces a new durable retry lifecycle and contradicts the current
+  no-backfill contract.
+
+## Risks / Trade-offs
+
+- [Risk] A process-wide gate reduces creation concurrency.
+  → Mitigation: application creation is low-volume administrative intake, and the existing
+  duplicate path already lists all applications; correctness at the configured boundary is more
+  important than parallel throughput.
+- [Risk] A direct Extension write or another plugin instance can exceed the configured value.
+  → Mitigation: document the supported-path, single-instance boundary; broader admission control is
+  explicitly out of scope.
+- [Risk] Comment precheck can skip a Comment immediately before capacity is released.
+  → Mitigation: accept this conservative fail-closed race and preserve the established no-retry,
+  no-backfill model.
+- [Risk] Storage or settings outages temporarily reject legitimate applications.
+  → Mitigation: use a generic visitor error, emit aggregate operational diagnostics, and never
+  weaken the security limit on evaluation failure.
+- [Risk] A very large administrator-selected value weakens backlog protection.
+  → Mitigation: provide a safe default and clear help text while leaving the explicit policy choice
+  to the administrator.
+
+## Migration Plan
+
+No migration is required because the friend-link application feature has not been released. The
+setting, backend default, enforcement, theme documentation, and tests land as one initial contract.
+Rollback removes the guard and setting without transforming LinkApplication resources.
+
+## Open Questions
+
+None. Capacity scope, counted state, concurrency boundary, visitor behavior, Comment behavior,
+failure handling, configuration semantics, and compatibility scope were confirmed during
+exploration.

--- a/openspec/changes/limit-pending-link-applications/proposal.md
+++ b/openspec/changes/limit-pending-link-applications/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+Friend-link application defenses currently limit individual visitor behavior but do not bound the
+total pending-review backlog shared by visitor submissions and Comment recognition. A configurable
+hard capacity prevents storage and review queues from growing without limit when applications are
+submitted through many URLs or sources.
+
+## What Changes
+
+- Add a Security subgroup to friend-link application settings with a required positive
+  `pendingCapacity` value that defaults to `100`.
+- Count only `PENDING` LinkApplications toward one capacity shared by visitor forms and Comment
+  recognition.
+- Enforce the capacity as a hard upper bound across supported creation paths within one plugin
+  instance, including concurrent submissions for different canonical URLs.
+- Preserve existing applications when the configured capacity is lowered and reject new
+  applications until the pending count falls below the configured value.
+- Return a stable visitor redirect when capacity is exhausted, while preserving the existing
+  CAPTCHA, rate-limit, validation, and duplicate-result ordering.
+- Skip Comment AI recognition when a capacity precheck is already full, repeat the authoritative
+  capacity check before persistence, and do not retry or backfill Comments skipped for capacity.
+- Fail closed when capacity configuration or the authoritative pending-count query is unavailable.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `link-application`: Add the pending-capacity setting, shared capacity semantics, full-capacity
+  visitor result, and cross-URL single-instance concurrency guarantee.
+- `comment-link-application-recognition`: Define capacity-aware model invocation, creation, and
+  no-retry behavior.
+
+## Impact
+
+- Backend: application settings DTO/fetching, shared LinkApplication creation coordination and
+  results, visitor form routing, Comment recognition, and focused concurrency/error handling.
+- Configuration: `application.security.pendingCapacity` in the plugin settings schema.
+- Theme contract: one additional `/links/apply` error redirect; form availability and CAPTCHA
+  endpoints remain unchanged while capacity is full.
+- Documentation and tests: update the theme API and add settings, service concurrency, route, and
+  Comment-recognition coverage.
+- No generated Console API change, data migration, legacy-setting compatibility, new dependency,
+  distributed quota, or direct Extension API admission control.

--- a/openspec/changes/limit-pending-link-applications/specs/comment-link-application-recognition/spec.md
+++ b/openspec/changes/limit-pending-link-applications/specs/comment-link-application-recognition/spec.md
@@ -1,0 +1,67 @@
+## ADDED Requirements
+
+### Requirement: Comment recognition avoids work while pending capacity is unavailable
+The system SHALL perform a non-authoritative pending-capacity precheck before invoking AI for a
+matching new Comment and SHALL fail closed when that precheck cannot establish available capacity.
+
+#### Scenario: Pending capacity is already exhausted
+- **WHEN** a matching new Comment reaches recognition while the pending count is greater than or
+  equal to capacity
+- **THEN** the system skips the Comment without invoking the model
+- **AND** does not create a LinkApplication
+
+#### Scenario: Capacity precheck cannot be evaluated
+- **WHEN** effective capacity settings or the indexed pending-count query are unavailable before
+  model invocation
+- **THEN** the system skips model invocation
+- **AND** does not create a LinkApplication
+- **AND** records an operational diagnostic without raw Comment content
+
+#### Scenario: Capacity is available before recognition
+- **WHEN** the capacity precheck reports an available slot
+- **THEN** an otherwise eligible Comment may proceed through the existing AI recognition flow
+- **AND** the precheck does not reserve a slot
+
+#### Scenario: Comment is skipped for capacity
+- **WHEN** recognition skips a Comment because capacity is full or unavailable
+- **THEN** the system does not retry that Comment
+- **AND** does not backfill it after capacity becomes available
+
+## MODIFIED Requirements
+
+### Requirement: Positive recognition creates a pending application
+The system SHALL create a traceable `PENDING` LinkApplication for a valid positive recognition only
+when the shared pending capacity remains available at authoritative creation time and SHALL NOT
+create a formal Link automatically.
+
+#### Scenario: Comment is recognized as a valid application
+- **WHEN** a matching Comment is positively classified with a resolved URL and display name
+- **AND** authoritative pending capacity remains available
+- **THEN** the system creates one LinkApplication with status `PENDING`
+- **AND** sets its origin type to `COMMENT`
+- **AND** records the source Comment metadata name as `origin.comment.name`
+- **AND** copies the owner email locally when the Comment has an email owner
+- **AND** does not create a Link
+
+#### Scenario: Capacity is consumed during recognition
+- **WHEN** the capacity precheck allows model invocation
+- **AND** another supported creation consumes the final slot before authoritative creation
+- **THEN** the system does not create a LinkApplication
+- **AND** records a capacity-skipped outcome without treating normal fullness as an operational error
+- **AND** does not retry or backfill the Comment
+
+#### Scenario: Authoritative capacity evaluation fails after recognition
+- **WHEN** a Comment is positively classified
+- **AND** authoritative capacity evaluation is unavailable before persistence
+- **THEN** the system does not create a LinkApplication
+- **AND** records an operational diagnostic without raw Comment content
+- **AND** does not retry or backfill the Comment
+
+#### Scenario: Same Comment is delivered more than once
+- **WHEN** processing is attempted again for a Comment that already produced an application
+- **THEN** the system does not create another LinkApplication
+
+#### Scenario: Source Comment changes after creation
+- **WHEN** the source Comment is edited or deleted after its application is created
+- **THEN** the LinkApplication retains its original extracted application fields
+- **AND** continues to reference the original Comment name

--- a/openspec/changes/limit-pending-link-applications/specs/link-application/spec.md
+++ b/openspec/changes/limit-pending-link-applications/specs/link-application/spec.md
@@ -1,0 +1,139 @@
+## ADDED Requirements
+
+### Requirement: Administrators can configure pending application capacity
+The system SHALL expose `application.security.pendingCapacity` as a required positive integer under
+a Security subgroup of friend-link application settings and SHALL use `100` as both the settings
+schema and backend default.
+
+#### Scenario: Administrator opens enabled application settings
+- **WHEN** the friend-link application master switch is enabled
+- **THEN** the settings form displays a Security subgroup
+- **AND** displays a pending application capacity field with default value `100`
+- **AND** explains that new applications pause at the limit until the pending count decreases
+
+#### Scenario: Administrator configures a positive capacity
+- **WHEN** the administrator saves a positive integer capacity
+- **THEN** the system uses that value for subsequent supported application creation
+
+#### Scenario: Administrator enters a non-positive capacity
+- **WHEN** the administrator enters `0` or a negative capacity
+- **THEN** settings validation rejects the value
+- **AND** `0` is not interpreted as unlimited or disabled
+
+#### Scenario: Capacity has no configured maximum
+- **WHEN** the administrator configures a positive integer above the default
+- **THEN** the settings schema does not reject it solely for exceeding an artificial maximum
+
+#### Scenario: Application settings have not been persisted
+- **WHEN** the application feature uses its initial unsaved settings
+- **THEN** the backend pending application capacity is `100`
+
+#### Scenario: Saved capacity is malformed
+- **WHEN** the saved pending application capacity is explicitly malformed or non-positive
+- **THEN** the system treats new application creation as unavailable
+- **AND** does not fall back to an unlimited capacity
+
+### Requirement: Pending capacity governs supported application creation
+The system SHALL admit a new LinkApplication through supported plugin creation paths only when the
+current number of `PENDING` LinkApplications is strictly less than the effective pending capacity.
+
+#### Scenario: Visitor and Comment applications share capacity
+- **WHEN** FORM-origin and COMMENT-origin LinkApplications are pending
+- **THEN** both origins contribute to the same pending capacity
+
+#### Scenario: Only pending applications consume capacity
+- **WHEN** the system evaluates capacity
+- **THEN** it counts LinkApplications with status `PENDING`
+- **AND** does not count `APPROVING`, `APPROVED`, or `REJECTED` applications
+
+#### Scenario: Capacity has one remaining slot
+- **WHEN** the pending count is one less than the configured capacity
+- **THEN** one otherwise valid supported creation may persist a new `PENDING` LinkApplication
+
+#### Scenario: Capacity is exhausted
+- **WHEN** the pending count is greater than or equal to the configured capacity
+- **THEN** supported creation returns a distinct capacity-reached result
+- **AND** does not persist a LinkApplication
+- **AND** does not publish a new-application notification
+
+#### Scenario: Capacity is lowered below the current count
+- **WHEN** an administrator lowers capacity below the number of existing pending applications
+- **THEN** the system preserves every existing application and its current status
+- **AND** rejects supported new creation until the pending count becomes lower than the new capacity
+
+#### Scenario: Pending application leaves the queue
+- **WHEN** a pending application becomes `APPROVING` or `REJECTED`, or is deleted
+- **THEN** it no longer consumes pending capacity
+
+#### Scenario: Authoritative capacity cannot be evaluated
+- **WHEN** effective capacity settings or the authoritative pending application query are unavailable
+- **THEN** supported creation fails closed
+- **AND** does not persist a LinkApplication
+
+#### Scenario: Privileged caller writes directly through the Extension API
+- **WHEN** a caller bypasses the plugin's shared creation service and writes a LinkApplication
+  directly through Halo's Extension API
+- **THEN** this capability does not guarantee enforcement for that write
+
+### Requirement: Single-instance pending capacity is concurrency-safe
+The system SHALL serialize authoritative capacity evaluation and persistence across all supported
+LinkApplication creation attempts within one plugin instance.
+
+#### Scenario: Different URLs compete for one remaining slot
+- **WHEN** two otherwise valid requests with different canonical URLs concurrently observe one
+  remaining pending slot
+- **THEN** at most one request persists a new `PENDING` LinkApplication
+- **AND** the other request receives the capacity-reached result
+
+#### Scenario: Capacity coordination finishes
+- **WHEN** an authoritative creation operation succeeds, is rejected, or fails
+- **THEN** the process-wide creation gate is released
+- **AND** later creation attempts can evaluate current capacity
+
+#### Scenario: Another plugin instance creates an application
+- **WHEN** supported creation executes in more than one plugin instance
+- **THEN** this capability does not guarantee a distributed hard upper bound
+
+### Requirement: Visitor submissions report pending capacity outcomes
+The system SHALL preserve visitor security checks and duplicate behavior before reporting pending
+capacity outcomes from `/links/apply`.
+
+#### Scenario: Visitor submission reaches full capacity
+- **WHEN** a visitor passes CAPTCHA and the IP submission limit with otherwise valid,
+  non-duplicate input
+- **AND** pending capacity is exhausted
+- **THEN** the system does not persist a LinkApplication
+- **AND** redirects to
+  `/links?applied=error&message=待审核申请数量已达上限，请稍后再试`
+- **AND** the redirect does not include `field`, `value`, or the configured capacity
+
+#### Scenario: Duplicate submission reaches full capacity
+- **WHEN** a visitor submission is both a duplicate under existing source-aware rules and received
+  while pending capacity is exhausted
+- **THEN** the system returns the existing duplicate result instead of the capacity-reached result
+
+#### Scenario: Full-capacity submission consumes abuse controls
+- **WHEN** a valid CAPTCHA and IP submission allowance reach authoritative creation while capacity
+  is full
+- **THEN** the CAPTCHA remains consumed
+- **AND** the IP submission allowance remains consumed
+
+#### Scenario: Capacity is full while the theme renders
+- **WHEN** the application master and visitor-submission switches are enabled while capacity is full
+- **THEN** the template model continues to expose `linkApplicationEnabled` as true
+- **AND** the CAPTCHA endpoint remains available according to its existing security limits
+
+#### Scenario: Visitor capacity evaluation fails
+- **WHEN** authoritative capacity evaluation fails after visitor abuse controls pass
+- **THEN** the system does not persist a LinkApplication
+- **AND** redirects to `/links?applied=error&message=暂时无法提交，请稍后再试`
+- **AND** the redirect does not include `field` or `value`
+
+#### Scenario: Full capacity is handled normally
+- **WHEN** visitor creation returns the capacity-reached result
+- **THEN** the system does not emit a warning or error log for that normal result
+
+#### Scenario: Capacity evaluation fails operationally
+- **WHEN** visitor capacity evaluation fails because settings or storage are unavailable
+- **THEN** the system records an operational diagnostic
+- **AND** the diagnostic excludes application fields and other attacker-controlled values

--- a/openspec/changes/limit-pending-link-applications/tasks.md
+++ b/openspec/changes/limit-pending-link-applications/tasks.md
@@ -1,0 +1,69 @@
+## 1. Application Security Setting
+
+- [x] 1.1 Extend settings tests first for the backend default `100`, a positive custom value,
+  rejected non-positive or malformed values, and fail-closed application creation when effective
+  capacity is unavailable.
+- [x] 1.2 Add the conditional Application Security subgroup and required
+  `security.pendingCapacity` number field with minimum `1`, default `100`, and the confirmed help
+  text.
+- [x] 1.3 Extend `LinkApplicationSettings` and its fetcher with the Security child settings,
+  backend default, positive-value validation, and no legacy compatibility or migration branch.
+
+## 2. Shared Capacity Evaluation
+
+- [x] 2.1 Add focused capacity-evaluator tests proving FORM and COMMENT origins share one pool,
+  only `PENDING` counts, 99/100 is available, 100/100 is full, a lowered limit preserves existing
+  data, and settings or indexed-count failures fail closed.
+- [x] 2.2 Implement reusable capacity evaluation that uses the `spec.status=PENDING` index for the
+  Comment precheck and can evaluate the already-loaded LinkApplication list during authoritative
+  creation.
+- [x] 2.3 Verify the evaluator introduces no persisted counter, LinkApplication field, generated
+  API change, direct Extension API admission control, or distributed coordination.
+
+## 3. Authoritative Creation and Concurrency
+
+- [x] 3.1 Extend `LinkApplicationService` tests first for the distinct capacity-reached result,
+  duplicate-before-capacity ordering, no persistence or notification while full, operational
+  failure propagation, and capacity release after pending applications leave the queue.
+- [x] 3.2 Add a concurrent different-URL test proving that two requests competing for one remaining
+  slot persist at most one application, while existing same-URL FORM/COMMENT and approval
+  coordination tests remain green.
+- [x] 3.3 Add the process-wide asynchronous creation gate, acquire it before canonical-URL
+  coordination, release it on every terminal signal, and keep authoritative settings, duplicate,
+  count, and create work inside the guarded operation.
+- [x] 3.4 Return capacity exhaustion as normal control flow, keep settings/storage failures
+  operational, and ensure only successful persistence invokes the notification publisher.
+
+## 4. Visitor Submission Contract
+
+- [x] 4.1 Extend router tests first for the exact full-capacity 303 redirect, the exact temporary
+  failure redirect, absence of `field`, `value`, and capacity disclosure, and preserved duplicate
+  precedence.
+- [x] 4.2 Add ordering tests proving full-capacity requests consume valid CAPTCHA and IP allowances,
+  while `linkApplicationEnabled` and `GET /links/captcha` remain governed only by their existing
+  switches and security limits.
+- [x] 4.3 Map shared capacity results and operational failures in `LinkRouter`, suppress logs for
+  normal fullness, and emit only aggregate diagnostics without submitted application values for
+  real failures.
+- [x] 4.4 Update `dev/theme-api.md` with the capacity-full and temporarily-unavailable redirects,
+  retained CAPTCHA behavior, and the absence of a dynamic capacity value in the theme model.
+
+## 5. Comment Recognition Contract
+
+- [x] 5.1 Extend Comment recognition tests first for full-capacity precheck without an AI call,
+  unavailable-precheck fail-closed behavior, available non-reserving precheck, and diagnostics that
+  exclude raw Comment content.
+- [x] 5.2 Add the indexed precheck before AI invocation, then map authoritative capacity exhaustion
+  after a positive result to a capacity-skipped outcome without warning-level logging.
+- [x] 5.3 Add race and lifecycle tests proving a slot consumed during AI work prevents persistence
+  and that capacity-skipped or capacity-failed Comments are never retried or backfilled.
+
+## 6. Validation
+
+- [x] 6.1 Run focused settings, capacity, service concurrency, route, Comment recognition, and
+  notification tests and confirm every new failure mode is fail closed.
+- [x] 6.2 Run `./gradlew test` and `./gradlew build`, then resolve only failures caused by this
+  change.
+- [x] 6.3 Run strict OpenSpec validation for `limit-pending-link-applications`,
+  `git diff --check`, and a final scope review confirming no migration, compatibility branch,
+  Console capacity UI, generated client change, or unrelated cleanup was introduced.

--- a/src/main/java/run/halo/links/dto/LinkApplicationSettings.java
+++ b/src/main/java/run/halo/links/dto/LinkApplicationSettings.java
@@ -11,9 +11,13 @@ import lombok.Data;
 @Schema(description = "Link application settings.")
 public class LinkApplicationSettings {
 
+    public static final int DEFAULT_PENDING_CAPACITY = 100;
+
     private Boolean enabled;
 
     private SelfSubmission selfSubmission;
+
+    private Security security;
 
     private CommentRecognition commentRecognition;
 
@@ -23,6 +27,7 @@ public class LinkApplicationSettings {
         var settings = new LinkApplicationSettings();
         settings.setEnabled(false);
         settings.setSelfSubmission(SelfSubmission.defaults());
+        settings.setSecurity(Security.defaults());
         settings.setCommentRecognition(CommentRecognition.defaults());
         settings.setNotification(Notification.defaults());
         return settings;
@@ -34,6 +39,9 @@ public class LinkApplicationSettings {
         settings.setSelfSubmission(selfSubmission == null
             ? SelfSubmission.defaults()
             : selfSubmission.normalized());
+        settings.setSecurity(security == null
+            ? Security.defaults()
+            : security.normalized());
         settings.setCommentRecognition(commentRecognition == null
             ? CommentRecognition.defaults()
             : commentRecognition.normalized());
@@ -51,6 +59,12 @@ public class LinkApplicationSettings {
         return applicationEnabled()
             && selfSubmission != null
             && selfSubmission.enabled();
+    }
+
+    public int pendingCapacity() {
+        return security == null
+            ? DEFAULT_PENDING_CAPACITY
+            : security.pendingCapacity();
     }
 
     public boolean commentRecognitionEnabled() {
@@ -105,6 +119,33 @@ public class LinkApplicationSettings {
 
         boolean enabled() {
             return enabled == null || Boolean.TRUE.equals(enabled);
+        }
+    }
+
+    @Data
+    public static class Security {
+
+        private Integer pendingCapacity;
+
+        static Security defaults() {
+            var settings = new Security();
+            settings.setPendingCapacity(DEFAULT_PENDING_CAPACITY);
+            return settings;
+        }
+
+        Security normalized() {
+            var settings = new Security();
+            if (pendingCapacity != null && pendingCapacity < 1) {
+                throw new IllegalArgumentException("Pending application capacity must be positive");
+            }
+            settings.setPendingCapacity(pendingCapacity == null
+                ? DEFAULT_PENDING_CAPACITY
+                : pendingCapacity);
+            return settings;
+        }
+
+        int pendingCapacity() {
+            return pendingCapacity == null ? DEFAULT_PENDING_CAPACITY : pendingCapacity;
         }
     }
 

--- a/src/main/java/run/halo/links/dto/LinkApplicationSettings.java
+++ b/src/main/java/run/halo/links/dto/LinkApplicationSettings.java
@@ -1,6 +1,8 @@
 package run.halo.links.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -61,9 +63,9 @@ public class LinkApplicationSettings {
             && selfSubmission.enabled();
     }
 
-    public int pendingCapacity() {
+    public BigInteger pendingCapacity() {
         return security == null
-            ? DEFAULT_PENDING_CAPACITY
+            ? BigInteger.valueOf(DEFAULT_PENDING_CAPACITY)
             : security.pendingCapacity();
     }
 
@@ -125,27 +127,39 @@ public class LinkApplicationSettings {
     @Data
     public static class Security {
 
-        private Integer pendingCapacity;
+        private BigDecimal pendingCapacity;
 
         static Security defaults() {
             var settings = new Security();
-            settings.setPendingCapacity(DEFAULT_PENDING_CAPACITY);
+            settings.setPendingCapacity(BigDecimal.valueOf(DEFAULT_PENDING_CAPACITY));
             return settings;
         }
 
         Security normalized() {
             var settings = new Security();
-            if (pendingCapacity != null && pendingCapacity < 1) {
-                throw new IllegalArgumentException("Pending application capacity must be positive");
-            }
-            settings.setPendingCapacity(pendingCapacity == null
-                ? DEFAULT_PENDING_CAPACITY
-                : pendingCapacity);
+            settings.setPendingCapacity(new BigDecimal(validatedPendingCapacity()));
             return settings;
         }
 
-        int pendingCapacity() {
-            return pendingCapacity == null ? DEFAULT_PENDING_CAPACITY : pendingCapacity;
+        BigInteger pendingCapacity() {
+            return validatedPendingCapacity();
+        }
+
+        private BigInteger validatedPendingCapacity() {
+            var value = pendingCapacity == null
+                ? BigDecimal.valueOf(DEFAULT_PENDING_CAPACITY)
+                : pendingCapacity;
+            try {
+                var integer = value.toBigIntegerExact();
+                if (integer.signum() < 1) {
+                    throw new IllegalArgumentException(
+                        "Pending application capacity must be a positive integer");
+                }
+                return integer;
+            } catch (ArithmeticException error) {
+                throw new IllegalArgumentException(
+                    "Pending application capacity must be a positive integer", error);
+            }
         }
     }
 

--- a/src/main/java/run/halo/links/recognition/CommentApplicationRecognitionProcessor.java
+++ b/src/main/java/run/halo/links/recognition/CommentApplicationRecognitionProcessor.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
@@ -26,6 +27,7 @@ import run.halo.links.endpoint.AiFoundationAvailableCondition;
 import run.halo.links.endpoint.LinkApplicationSettingsFetcher;
 import run.halo.links.extension.LinkApplication;
 import run.halo.links.route.LinkBaseSettings;
+import run.halo.links.service.LinkApplicationCapacityService;
 import run.halo.links.service.LinkApplicationService;
 import run.halo.links.service.LinkUrlCanonicalizer;
 import run.halo.links.service.ai.LinkAiService;
@@ -36,6 +38,7 @@ import run.halo.links.service.ai.LinkAiService;
 @Component
 @RequiredArgsConstructor
 @Conditional(AiFoundationAvailableCondition.class)
+@Slf4j
 public class CommentApplicationRecognitionProcessor {
 
     private static final String BASE_SETTING_GROUP = "base";
@@ -43,6 +46,7 @@ public class CommentApplicationRecognitionProcessor {
     private final LinkApplicationSettingsFetcher applicationSettingsFetcher;
     private final LinkAiService aiService;
     private final LinkApplicationService applicationService;
+    private final LinkApplicationCapacityService capacityService;
     private final ReactiveExtensionClient extensionClient;
     private final ReactiveSettingFetcher settingFetcher;
     private final PluginContext pluginContext;
@@ -65,15 +69,29 @@ public class CommentApplicationRecognitionProcessor {
                     return Mono.just(ProcessOutcome.SKIPPED);
                 }
                 var modelName = settings.commentRecognitionModelName();
-                return aiService.isOperational(modelName)
-                    .onErrorReturn(false)
-                    .flatMap(operational -> {
-                        if (!operational) {
-                            return Mono.just(ProcessOutcome.SKIPPED);
+                return capacityService.isAvailable()
+                    .onErrorResume(error -> {
+                        log.error("[plugin-links] Failed to evaluate pending application capacity "
+                                + "for Comment recognition: errorType={}",
+                            error.getClass().getName());
+                        return Mono.empty();
+                    })
+                    .flatMap(available -> {
+                        if (!available) {
+                            return Mono.just(ProcessOutcome.CAPACITY_REACHED);
                         }
-                        return subjectTitle(source.get())
-                            .flatMap(title -> analyze(comment, source.get(), title, modelName));
-                    });
+                        return aiService.isOperational(modelName)
+                            .onErrorReturn(false)
+                            .flatMap(operational -> {
+                                if (!operational) {
+                                    return Mono.just(ProcessOutcome.SKIPPED);
+                                }
+                                return subjectTitle(source.get())
+                                    .flatMap(title ->
+                                        analyze(comment, source.get(), title, modelName));
+                            });
+                    })
+                    .switchIfEmpty(Mono.just(ProcessOutcome.SKIPPED));
             });
     }
 
@@ -137,6 +155,7 @@ public class CommentApplicationRecognitionProcessor {
                 case CREATED -> ProcessOutcome.CREATED;
                 case DUPLICATE -> ProcessOutcome.DUPLICATE;
                 case INVALID -> ProcessOutcome.INVALID;
+                case CAPACITY_REACHED -> ProcessOutcome.CAPACITY_REACHED;
             });
     }
 
@@ -236,6 +255,7 @@ public class CommentApplicationRecognitionProcessor {
         NEGATIVE,
         INVALID,
         DUPLICATE,
+        CAPACITY_REACHED,
         CREATED
     }
 }

--- a/src/main/java/run/halo/links/route/LinkRouter.java
+++ b/src/main/java/run/halo/links/route/LinkRouter.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.domain.Sort;
@@ -42,6 +43,7 @@ import run.halo.links.vo.LinkVo;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class LinkRouter {
 
     private static final Duration BLOCKING_TIMEOUT = Duration.ofSeconds(10);
@@ -104,14 +106,19 @@ public class LinkRouter {
                         origin
                     );
                     return applicationService.create(submission)
-                        .flatMap(result -> {
-                            if (result.status()
-                                == LinkApplicationService.CreateStatus.CREATED) {
-                                return redirectSuccess();
-                            }
-                            return redirectWithFieldError(result.field(), result.value(),
-                                result.message());
-                        });
+                        .flatMap(result -> switch (result.status()) {
+                            case CREATED -> redirectSuccess();
+                            case CAPACITY_REACHED ->
+                                redirectWithError("待审核申请数量已达上限，请稍后再试");
+                            case DUPLICATE, INVALID ->
+                                redirectWithFieldError(result.field(), result.value(),
+                                    result.message());
+                        })
+                        .doOnError(error -> log.error(
+                            "[plugin-links] Failed to create link application: errorType={}",
+                            error.getClass().getName()))
+                        .onErrorResume(error ->
+                            redirectWithError("暂时无法提交，请稍后再试"));
                 });
             });
     }

--- a/src/main/java/run/halo/links/service/LinkApplicationCapacityService.java
+++ b/src/main/java/run/halo/links/service/LinkApplicationCapacityService.java
@@ -1,0 +1,63 @@
+package run.halo.links.service;
+
+import static run.halo.app.extension.index.query.Queries.equal;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+import run.halo.app.extension.ListOptions;
+import run.halo.app.extension.ReactiveExtensionClient;
+import run.halo.links.dto.LinkApplicationSettings;
+import run.halo.links.endpoint.LinkApplicationSettingsFetcher;
+import run.halo.links.extension.LinkApplication;
+
+/**
+ * Evaluates the shared pending LinkApplication capacity.
+ */
+@Component
+@RequiredArgsConstructor
+public class LinkApplicationCapacityService {
+
+    private final ReactiveExtensionClient client;
+    private final LinkApplicationSettingsFetcher settingsFetcher;
+
+    public Mono<Boolean> isAvailable() {
+        return requireEnabledSettings()
+            .flatMap(settings -> client.countBy(LinkApplication.class, pendingOptions())
+                .map(pendingCount -> pendingCount < settings.pendingCapacity()));
+    }
+
+    public Mono<Boolean> isAvailable(List<LinkApplication> applications) {
+        return requireEnabledSettings()
+            .map(settings -> pendingCount(applications) < settings.pendingCapacity());
+    }
+
+    private Mono<LinkApplicationSettings> requireEnabledSettings() {
+        return settingsFetcher.fetch()
+            .flatMap(settings -> settings.applicationEnabled()
+                ? Mono.just(settings)
+                : Mono.error(new CapacityUnavailableException()));
+    }
+
+    private static long pendingCount(List<LinkApplication> applications) {
+        return applications.stream()
+            .filter(application -> application.getSpec() != null)
+            .filter(application ->
+                application.getSpec().getStatus() == LinkApplication.Status.PENDING)
+            .count();
+    }
+
+    private static ListOptions pendingOptions() {
+        return ListOptions.builder()
+            .andQuery(equal("spec.status", LinkApplication.Status.PENDING.name()))
+            .build();
+    }
+
+    public static class CapacityUnavailableException extends RuntimeException {
+
+        public CapacityUnavailableException() {
+            super("Pending application capacity is unavailable");
+        }
+    }
+}

--- a/src/main/java/run/halo/links/service/LinkApplicationCapacityService.java
+++ b/src/main/java/run/halo/links/service/LinkApplicationCapacityService.java
@@ -2,6 +2,7 @@ package run.halo.links.service;
 
 import static run.halo.app.extension.index.query.Queries.equal;
 
+import java.math.BigInteger;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -25,12 +26,13 @@ public class LinkApplicationCapacityService {
     public Mono<Boolean> isAvailable() {
         return requireEnabledSettings()
             .flatMap(settings -> client.countBy(LinkApplication.class, pendingOptions())
-                .map(pendingCount -> pendingCount < settings.pendingCapacity()));
+                .map(pendingCount -> isBelowCapacity(pendingCount, settings.pendingCapacity())));
     }
 
     public Mono<Boolean> isAvailable(List<LinkApplication> applications) {
         return requireEnabledSettings()
-            .map(settings -> pendingCount(applications) < settings.pendingCapacity());
+            .map(settings ->
+                isBelowCapacity(pendingCount(applications), settings.pendingCapacity()));
     }
 
     private Mono<LinkApplicationSettings> requireEnabledSettings() {
@@ -46,6 +48,10 @@ public class LinkApplicationCapacityService {
             .filter(application ->
                 application.getSpec().getStatus() == LinkApplication.Status.PENDING)
             .count();
+    }
+
+    private static boolean isBelowCapacity(long pendingCount, BigInteger capacity) {
+        return BigInteger.valueOf(pendingCount).compareTo(capacity) < 0;
     }
 
     private static ListOptions pendingOptions() {

--- a/src/main/java/run/halo/links/service/LinkApplicationCreationCoordinator.java
+++ b/src/main/java/run/halo/links/service/LinkApplicationCreationCoordinator.java
@@ -8,13 +8,40 @@ import reactor.core.publisher.Mono;
 import reactor.core.publisher.Sinks;
 
 /**
- * Serializes application creation and approval reservation by canonical URL within one plugin
- * process.
+ * Serializes application creation globally and URL occupancy work by canonical URL within one
+ * plugin process.
  */
 @Component
 public class LinkApplicationCreationCoordinator {
 
     private final Map<String, Entry> entries = new HashMap<>();
+    private final Entry creationEntry = new Entry();
+
+    public <T> Mono<T> coordinateCreation(Supplier<Mono<T>> work) {
+        return Mono.defer(() -> {
+            var completion = Sinks.<Void>empty();
+            Mono<Void> predecessor;
+            synchronized (creationEntry) {
+                predecessor = creationEntry.tail;
+                creationEntry.tail = predecessor
+                    .onErrorResume(error -> Mono.empty())
+                    .then(completion.asMono());
+                creationEntry.references++;
+            }
+            return predecessor
+                .onErrorResume(error -> Mono.empty())
+                .then(Mono.defer(work))
+                .doFinally(signalType -> {
+                    completion.tryEmitEmpty();
+                    synchronized (creationEntry) {
+                        creationEntry.references--;
+                        if (creationEntry.references == 0) {
+                            creationEntry.tail = Mono.empty();
+                        }
+                    }
+                });
+        });
+    }
 
     public <T> Mono<T> coordinate(String key, Supplier<Mono<T>> work) {
         return Mono.defer(() -> {
@@ -24,7 +51,9 @@ public class LinkApplicationCreationCoordinator {
             synchronized (entries) {
                 entry = entries.computeIfAbsent(key, ignored -> new Entry());
                 predecessor = entry.tail;
-                entry.tail = completion.asMono();
+                entry.tail = predecessor
+                    .onErrorResume(error -> Mono.empty())
+                    .then(completion.asMono());
                 entry.references++;
             }
             return predecessor

--- a/src/main/java/run/halo/links/service/LinkApplicationService.java
+++ b/src/main/java/run/halo/links/service/LinkApplicationService.java
@@ -24,6 +24,7 @@ public class LinkApplicationService {
 
     private final ReactiveExtensionClient client;
     private final LinkApplicationCreationCoordinator creationCoordinator;
+    private final LinkApplicationCapacityService capacityService;
 
     private final LinkApplicationNotificationPublisher notificationPublisher;
 
@@ -33,8 +34,9 @@ public class LinkApplicationService {
             return Mono.just(validation);
         }
         var canonicalUrl = LinkUrlCanonicalizer.canonicalKey(submission.url()).orElseThrow();
-        return creationCoordinator.coordinate(canonicalUrl,
-            () -> createCoordinated(submission, canonicalUrl));
+        return creationCoordinator.coordinateCreation(() ->
+            creationCoordinator.coordinate(canonicalUrl,
+                () -> createCoordinated(submission, canonicalUrl)));
     }
 
     private Mono<CreateResult> createCoordinated(Submission submission, String canonicalUrl) {
@@ -48,15 +50,22 @@ public class LinkApplicationService {
                     || hasDuplicateApplication(existing.getT2(), submission, canonicalUrl)) {
                     return Mono.just(CreateResult.duplicate(submission.url().trim()));
                 }
-                var application = toApplication(submission);
-                return client.create(application)
-                    .flatMap(created -> notificationPublisher.publish(created)
-                        .doOnError(error -> log.warn(
-                            "[plugin-links] Failed to publish notification for application [{}]",
-                            created.getMetadata().getName(), error))
-                        .onErrorResume(error -> Mono.empty())
-                        .thenReturn(created))
-                    .map(CreateResult::created);
+                return capacityService.isAvailable(existing.getT2())
+                    .flatMap(available -> {
+                        if (!available) {
+                            return Mono.just(CreateResult.capacityReached());
+                        }
+                        var application = toApplication(submission);
+                        return client.create(application)
+                            .flatMap(created -> notificationPublisher.publish(created)
+                                .doOnError(error -> log.warn(
+                                    "[plugin-links] Failed to publish notification for "
+                                        + "application [{}]",
+                                    created.getMetadata().getName(), error))
+                                .onErrorResume(error -> Mono.empty())
+                                .thenReturn(created))
+                            .map(CreateResult::created);
+                    });
             });
     }
 
@@ -215,11 +224,16 @@ public class LinkApplicationService {
         static CreateResult invalid(String field, String value, String message) {
             return new CreateResult(CreateStatus.INVALID, null, field, value, message);
         }
+
+        static CreateResult capacityReached() {
+            return new CreateResult(CreateStatus.CAPACITY_REACHED, null, null, null, null);
+        }
     }
 
     public enum CreateStatus {
         CREATED,
         DUPLICATE,
-        INVALID
+        INVALID,
+        CAPACITY_REACHED
     }
 }

--- a/src/main/resources/extensions/settings.yaml
+++ b/src/main/resources/extensions/settings.yaml
@@ -85,6 +85,17 @@ spec:
               help: 允许主题通过 /links/apply 提交表单，主题应根据 linkApplicationEnabled 决定是否展示申请入口
         - $formkit: group
           if: "$get(link_application_enabled).value === true"
+          name: security
+          label: 安全
+          children:
+            - $formkit: number
+              label: 待审核申请容量
+              name: pendingCapacity
+              validation: required|number|min:1
+              value: 100
+              help: 限制待审核友链申请的最大数量。达到上限后将暂停接收新申请，直到待审核数量下降。
+        - $formkit: group
+          if: "$get(link_application_enabled).value === true"
           name: commentRecognition
           label: 从新评论中识别友链申请
           children:

--- a/src/main/resources/extensions/settings.yaml
+++ b/src/main/resources/extensions/settings.yaml
@@ -91,7 +91,8 @@ spec:
             - $formkit: number
               label: 待审核申请容量
               name: pendingCapacity
-              validation: required|number|min:1
+              step: 1
+              validation: 'required|number|min:1|matches:/^[1-9][0-9]*$/'
               value: 100
               help: 限制待审核友链申请的最大数量。达到上限后将暂停接收新申请，直到待审核数量下降。
         - $formkit: group

--- a/src/test/java/run/halo/links/endpoint/LinkApplicationSettingsFetcherTest.java
+++ b/src/test/java/run/halo/links/endpoint/LinkApplicationSettingsFetcherTest.java
@@ -131,6 +131,63 @@ class LinkApplicationSettingsFetcherTest {
             .verifyComplete();
     }
 
+    @Test
+    void shouldDefaultPendingCapacityToOneHundred() {
+        var raw = new LinkApplicationSettings();
+        raw.setEnabled(true);
+        when(settingFetcher.fetch(LinkApplicationSettingsFetcher.SETTING_GROUP,
+            LinkApplicationSettings.class)).thenReturn(Mono.just(raw));
+
+        StepVerifier.create(new LinkApplicationSettingsFetcher(settingFetcher).fetch())
+            .assertNext(settings -> {
+                assertThat(settings.applicationEnabled()).isTrue();
+                assertThat(settings.pendingCapacity()).isEqualTo(100);
+            })
+            .verifyComplete();
+    }
+
+    @Test
+    void shouldKeepPositivePendingCapacity() {
+        var raw = new LinkApplicationSettings();
+        raw.setEnabled(true);
+        var security = new LinkApplicationSettings.Security();
+        security.setPendingCapacity(250);
+        raw.setSecurity(security);
+        when(settingFetcher.fetch(LinkApplicationSettingsFetcher.SETTING_GROUP,
+            LinkApplicationSettings.class)).thenReturn(Mono.just(raw));
+
+        StepVerifier.create(new LinkApplicationSettingsFetcher(settingFetcher).fetch())
+            .assertNext(settings -> {
+                assertThat(settings.applicationEnabled()).isTrue();
+                assertThat(settings.pendingCapacity()).isEqualTo(250);
+            })
+            .verifyComplete();
+    }
+
+    @Test
+    void shouldFailClosedForNonPositivePendingCapacity() {
+        var zero = new LinkApplicationSettings();
+        zero.setEnabled(true);
+        var zeroSecurity = new LinkApplicationSettings.Security();
+        zeroSecurity.setPendingCapacity(0);
+        zero.setSecurity(zeroSecurity);
+        var negative = new LinkApplicationSettings();
+        negative.setEnabled(true);
+        var negativeSecurity = new LinkApplicationSettings.Security();
+        negativeSecurity.setPendingCapacity(-1);
+        negative.setSecurity(negativeSecurity);
+        when(settingFetcher.fetch(LinkApplicationSettingsFetcher.SETTING_GROUP,
+            LinkApplicationSettings.class)).thenReturn(Mono.just(zero), Mono.just(negative));
+        var fetcher = new LinkApplicationSettingsFetcher(settingFetcher);
+
+        StepVerifier.create(fetcher.fetch())
+            .assertNext(settings -> assertThat(settings.applicationEnabled()).isFalse())
+            .verifyComplete();
+        StepVerifier.create(fetcher.fetch())
+            .assertNext(settings -> assertThat(settings.applicationEnabled()).isFalse())
+            .verifyComplete();
+    }
+
     private static LinkApplicationSettings.RecognitionSource source(
         LinkApplicationSettings.SourceType type, String name) {
         var source = new LinkApplicationSettings.RecognitionSource();

--- a/src/test/java/run/halo/links/endpoint/LinkApplicationSettingsFetcherTest.java
+++ b/src/test/java/run/halo/links/endpoint/LinkApplicationSettingsFetcherTest.java
@@ -3,6 +3,8 @@ package run.halo.links.endpoint;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,6 +14,7 @@ import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 import run.halo.app.plugin.ReactiveSettingFetcher;
 import run.halo.links.dto.LinkApplicationSettings;
+import tools.jackson.databind.json.JsonMapper;
 
 @ExtendWith(MockitoExtension.class)
 class LinkApplicationSettingsFetcherTest {
@@ -141,7 +144,7 @@ class LinkApplicationSettingsFetcherTest {
         StepVerifier.create(new LinkApplicationSettingsFetcher(settingFetcher).fetch())
             .assertNext(settings -> {
                 assertThat(settings.applicationEnabled()).isTrue();
-                assertThat(settings.pendingCapacity()).isEqualTo(100);
+                assertThat(settings.pendingCapacity()).isEqualTo(BigInteger.valueOf(100));
             })
             .verifyComplete();
     }
@@ -151,7 +154,7 @@ class LinkApplicationSettingsFetcherTest {
         var raw = new LinkApplicationSettings();
         raw.setEnabled(true);
         var security = new LinkApplicationSettings.Security();
-        security.setPendingCapacity(250);
+        security.setPendingCapacity(BigDecimal.valueOf(250));
         raw.setSecurity(security);
         when(settingFetcher.fetch(LinkApplicationSettingsFetcher.SETTING_GROUP,
             LinkApplicationSettings.class)).thenReturn(Mono.just(raw));
@@ -159,7 +162,7 @@ class LinkApplicationSettingsFetcherTest {
         StepVerifier.create(new LinkApplicationSettingsFetcher(settingFetcher).fetch())
             .assertNext(settings -> {
                 assertThat(settings.applicationEnabled()).isTrue();
-                assertThat(settings.pendingCapacity()).isEqualTo(250);
+                assertThat(settings.pendingCapacity()).isEqualTo(BigInteger.valueOf(250));
             })
             .verifyComplete();
     }
@@ -169,12 +172,12 @@ class LinkApplicationSettingsFetcherTest {
         var zero = new LinkApplicationSettings();
         zero.setEnabled(true);
         var zeroSecurity = new LinkApplicationSettings.Security();
-        zeroSecurity.setPendingCapacity(0);
+        zeroSecurity.setPendingCapacity(BigDecimal.ZERO);
         zero.setSecurity(zeroSecurity);
         var negative = new LinkApplicationSettings();
         negative.setEnabled(true);
         var negativeSecurity = new LinkApplicationSettings.Security();
-        negativeSecurity.setPendingCapacity(-1);
+        negativeSecurity.setPendingCapacity(BigDecimal.valueOf(-1));
         negative.setSecurity(negativeSecurity);
         when(settingFetcher.fetch(LinkApplicationSettingsFetcher.SETTING_GROUP,
             LinkApplicationSettings.class)).thenReturn(Mono.just(zero), Mono.just(negative));
@@ -184,6 +187,28 @@ class LinkApplicationSettingsFetcherTest {
             .assertNext(settings -> assertThat(settings.applicationEnabled()).isFalse())
             .verifyComplete();
         StepVerifier.create(fetcher.fetch())
+            .assertNext(settings -> assertThat(settings.applicationEnabled()).isFalse())
+            .verifyComplete();
+    }
+
+    @Test
+    void shouldFailClosedForFractionalPendingCapacity() {
+        var mapper = JsonMapper.builder().build();
+        var raw = mapper.convertValue(
+            mapper.readTree("""
+                {
+                  "enabled": true,
+                  "security": {
+                    "pendingCapacity": 1.5
+                  }
+                }
+                """),
+            LinkApplicationSettings.class
+        );
+        when(settingFetcher.fetch(LinkApplicationSettingsFetcher.SETTING_GROUP,
+            LinkApplicationSettings.class)).thenReturn(Mono.just(raw));
+
+        StepVerifier.create(new LinkApplicationSettingsFetcher(settingFetcher).fetch())
             .assertNext(settings -> assertThat(settings.applicationEnabled()).isFalse())
             .verifyComplete();
     }

--- a/src/test/java/run/halo/links/recognition/CommentApplicationRecognitionProcessorTest.java
+++ b/src/test/java/run/halo/links/recognition/CommentApplicationRecognitionProcessorTest.java
@@ -2,6 +2,8 @@ package run.halo.links.recognition;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -21,6 +23,7 @@ import run.halo.app.core.extension.content.Comment;
 import run.halo.app.core.extension.content.Post;
 import run.halo.app.core.extension.content.SinglePage;
 import run.halo.app.extension.GroupVersionKind;
+import run.halo.app.extension.ListOptions;
 import run.halo.app.extension.Metadata;
 import run.halo.app.extension.ReactiveExtensionClient;
 import run.halo.app.extension.Ref;
@@ -32,6 +35,7 @@ import run.halo.links.dto.LinkCommentRecognitionResult;
 import run.halo.links.endpoint.LinkApplicationSettingsFetcher;
 import run.halo.links.extension.LinkApplication;
 import run.halo.links.route.LinkBaseSettings;
+import run.halo.links.service.LinkApplicationCapacityService;
 import run.halo.links.service.LinkApplicationService;
 import run.halo.links.service.ai.LinkAiService;
 
@@ -60,10 +64,13 @@ class CommentApplicationRecognitionProcessorTest {
 
     @BeforeEach
     void setUp() {
+        lenient().when(extensionClient.countBy(eq(LinkApplication.class),
+            any(ListOptions.class))).thenReturn(Mono.just(0L));
         processor = new CommentApplicationRecognitionProcessor(
             applicationSettingsFetcher,
             aiService,
             applicationService,
+            new LinkApplicationCapacityService(extensionClient, applicationSettingsFetcher),
             extensionClient,
             settingFetcher,
             pluginContext
@@ -185,6 +192,70 @@ class CommentApplicationRecognitionProcessorTest {
         verify(aiService, never()).isOperational(any());
         verify(aiService, never()).recognize(any(), any());
         verify(applicationService, never()).create(any());
+    }
+
+    @Test
+    void shouldSkipModelInvocationWhenPendingCapacityIsFull() {
+        when(applicationSettingsFetcher.fetch()).thenReturn(Mono.just(
+            settings(source(LinkApplicationSettings.SourceType.POST, "post-a"))));
+        when(extensionClient.countBy(eq(LinkApplication.class), any(ListOptions.class)))
+            .thenReturn(Mono.just(100L));
+        var comment = comment("comment-a", Ref.of("post-a",
+            GroupVersionKind.fromExtension(Post.class)));
+
+        StepVerifier.create(processor.process(comment))
+            .expectNext(CommentApplicationRecognitionProcessor.ProcessOutcome.CAPACITY_REACHED)
+            .verifyComplete();
+
+        verify(aiService, never()).isOperational(any());
+        verify(aiService, never()).recognize(any(), any());
+        verify(applicationService, never()).create(any());
+    }
+
+    @Test
+    void shouldFailClosedWhenCapacityPrecheckIsUnavailable() {
+        when(applicationSettingsFetcher.fetch()).thenReturn(Mono.just(
+            settings(source(LinkApplicationSettings.SourceType.POST, "post-a"))));
+        when(extensionClient.countBy(eq(LinkApplication.class), any(ListOptions.class)))
+            .thenReturn(Mono.error(new IllegalStateException("count unavailable")));
+        var comment = comment("comment-a", Ref.of("post-a",
+            GroupVersionKind.fromExtension(Post.class)));
+
+        StepVerifier.create(processor.process(comment))
+            .expectNext(CommentApplicationRecognitionProcessor.ProcessOutcome.SKIPPED)
+            .verifyComplete();
+
+        verify(aiService, never()).isOperational(any());
+        verify(aiService, never()).recognize(any(), any());
+        verify(applicationService, never()).create(any());
+    }
+
+    @Test
+    void shouldReportCapacityConsumedDuringRecognition() {
+        when(applicationSettingsFetcher.fetch()).thenReturn(Mono.just(
+            settings(source(LinkApplicationSettings.SourceType.POST, "post-a"))));
+        when(aiService.isOperational("model-a")).thenReturn(Mono.just(true));
+        var post = new Post();
+        post.setSpec(new Post.PostSpec());
+        when(extensionClient.fetch(Post.class, "post-a")).thenReturn(Mono.just(post));
+        when(aiService.recognize(any(), any())).thenReturn(Mono.just(
+            new LinkCommentRecognitionResult(true, "https://example.com", "Example",
+                null, null, null, List.of())
+        ));
+        when(applicationService.create(any())).thenReturn(Mono.just(
+            new LinkApplicationService.CreateResult(
+                LinkApplicationService.CreateStatus.CAPACITY_REACHED,
+                null, null, null, null
+            )
+        ));
+
+        StepVerifier.create(processor.process(comment("comment-a", Ref.of("post-a",
+                GroupVersionKind.fromExtension(Post.class)))))
+            .expectNext(CommentApplicationRecognitionProcessor.ProcessOutcome.CAPACITY_REACHED)
+            .verifyComplete();
+
+        verify(aiService).recognize(any(), eq("model-a"));
+        verify(applicationService).create(any());
     }
 
     @Test

--- a/src/test/java/run/halo/links/route/LinkRouterTest.java
+++ b/src/test/java/run/halo/links/route/LinkRouterTest.java
@@ -270,7 +270,37 @@ class LinkRouterTest {
     }
 
     @Test
-    void shouldExpireCaptchaCookieWhenApplicationCreationFails() {
+    void shouldRedirectWhenPendingCapacityIsFull() {
+        when(applicationSettingsFetcher.fetch()).thenReturn(Mono.just(enabledSettings()));
+        when(captchaService.verify(any(), any())).thenReturn(validCaptcha());
+        when(rateLimiter.isAllowed(any())).thenReturn(true);
+        when(applicationService.create(any())).thenReturn(Mono.just(
+            new LinkApplicationService.CreateResult(
+                LinkApplicationService.CreateStatus.CAPACITY_REACHED,
+                null, null, null, null
+            )
+        ));
+        var client = WebTestClient.bindToRouterFunction(router().linkTemplateRoute()).build();
+
+        client.post()
+            .uri("/links/apply")
+            .body(BodyInserters.fromFormData("url", "https://example.com")
+                .with("displayName", "Example")
+                .with("captchaCode", "ABCDE"))
+            .exchange()
+            .expectStatus().is3xxRedirection()
+            .expectHeader().valueEquals("Location",
+                "/links?applied=error&message=%E5%BE%85%E5%AE%A1%E6%A0%B8%E7%94%B3%E8%AF%B7%E6%95%B0%E9%87%8F%E5%B7%B2%E8%BE%BE%E4%B8%8A%E9%99%90%EF%BC%8C%E8%AF%B7%E7%A8%8D%E5%90%8E%E5%86%8D%E8%AF%95")
+            .expectHeader().valueMatches(HttpHeaders.SET_COOKIE, ".*Max-Age=0.*");
+
+        var order = inOrder(captchaService, rateLimiter, applicationService);
+        order.verify(captchaService).verify(any(), any());
+        order.verify(rateLimiter).isAllowed(any());
+        order.verify(applicationService).create(any());
+    }
+
+    @Test
+    void shouldRedirectWhenApplicationCreationIsUnavailable() {
         when(applicationSettingsFetcher.fetch()).thenReturn(Mono.just(enabledSettings()));
         when(captchaService.verify(any(), any())).thenReturn(validCaptcha());
         when(rateLimiter.isAllowed(any())).thenReturn(true);
@@ -284,7 +314,9 @@ class LinkRouterTest {
                 .with("displayName", "Example")
                 .with("captchaCode", "ABCDE"))
             .exchange()
-            .expectStatus().is5xxServerError()
+            .expectStatus().is3xxRedirection()
+            .expectHeader().valueEquals("Location",
+                "/links?applied=error&message=%E6%9A%82%E6%97%B6%E6%97%A0%E6%B3%95%E6%8F%90%E4%BA%A4%EF%BC%8C%E8%AF%B7%E7%A8%8D%E5%90%8E%E5%86%8D%E8%AF%95")
             .expectHeader().valueMatches(HttpHeaders.SET_COOKIE, ".*Max-Age=0.*");
     }
 

--- a/src/test/java/run/halo/links/service/LinkApplicationCapacityServiceTest.java
+++ b/src/test/java/run/halo/links/service/LinkApplicationCapacityServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
+import java.math.BigDecimal;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -119,7 +120,7 @@ class LinkApplicationCapacityServiceTest {
         var settings = new LinkApplicationSettings();
         settings.setEnabled(true);
         var security = new LinkApplicationSettings.Security();
-        security.setPendingCapacity(capacity);
+        security.setPendingCapacity(BigDecimal.valueOf(capacity));
         settings.setSecurity(security);
         return settings;
     }

--- a/src/test/java/run/halo/links/service/LinkApplicationCapacityServiceTest.java
+++ b/src/test/java/run/halo/links/service/LinkApplicationCapacityServiceTest.java
@@ -1,0 +1,141 @@
+package run.halo.links.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+import run.halo.app.extension.ListOptions;
+import run.halo.app.extension.Metadata;
+import run.halo.app.extension.ReactiveExtensionClient;
+import run.halo.app.plugin.ReactiveSettingFetcher;
+import run.halo.links.dto.LinkApplicationSettings;
+import run.halo.links.endpoint.LinkApplicationSettingsFetcher;
+import run.halo.links.extension.LinkApplication;
+
+@ExtendWith(MockitoExtension.class)
+class LinkApplicationCapacityServiceTest {
+
+    @Mock
+    ReactiveExtensionClient client;
+
+    @Mock
+    ReactiveSettingFetcher settingFetcher;
+
+    LinkApplicationCapacityService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new LinkApplicationCapacityService(client,
+            new LinkApplicationSettingsFetcher(settingFetcher));
+    }
+
+    @Test
+    void shouldUseIndexedPendingCountAtBoundary() {
+        givenSettings(100);
+        when(client.countBy(eq(LinkApplication.class), any(ListOptions.class)))
+            .thenReturn(Mono.just(99L), Mono.just(100L));
+
+        StepVerifier.create(service.isAvailable())
+            .expectNext(true)
+            .verifyComplete();
+        StepVerifier.create(service.isAvailable())
+            .expectNext(false)
+            .verifyComplete();
+    }
+
+    @Test
+    void shouldCountPendingApplicationsAcrossOriginsOnly() {
+        givenSettings(2);
+        var formPending = application(LinkApplication.Status.PENDING,
+            LinkApplication.OriginType.FORM);
+        var commentPending = application(LinkApplication.Status.PENDING,
+            LinkApplication.OriginType.COMMENT);
+        var otherStatuses = List.of(
+            application(LinkApplication.Status.APPROVING, LinkApplication.OriginType.FORM),
+            application(LinkApplication.Status.APPROVED, LinkApplication.OriginType.COMMENT),
+            application(LinkApplication.Status.REJECTED, LinkApplication.OriginType.FORM)
+        );
+
+        StepVerifier.create(service.isAvailable(List.of(
+                formPending,
+                otherStatuses.get(0),
+                otherStatuses.get(1),
+                otherStatuses.get(2)
+            )))
+            .expectNext(true)
+            .verifyComplete();
+        StepVerifier.create(service.isAvailable(List.of(formPending, commentPending)))
+            .expectNext(false)
+            .verifyComplete();
+    }
+
+    @Test
+    void shouldNotMutateApplicationsWhenCapacityIsLowered() {
+        givenSettings(1);
+        var pending = application(LinkApplication.Status.PENDING,
+            LinkApplication.OriginType.FORM);
+        var applications = List.of(pending);
+
+        StepVerifier.create(service.isAvailable(applications))
+            .expectNext(false)
+            .verifyComplete();
+
+        assertThat(applications).containsExactly(pending);
+        assertThat(pending.getSpec().getStatus()).isEqualTo(LinkApplication.Status.PENDING);
+    }
+
+    @Test
+    void shouldFailClosedWhenSettingsOrCountAreUnavailable() {
+        var invalid = enabledSettings(0);
+        when(settingFetcher.fetch(LinkApplicationSettingsFetcher.SETTING_GROUP,
+            LinkApplicationSettings.class))
+            .thenReturn(Mono.just(invalid), Mono.just(enabledSettings(100)));
+        when(client.countBy(eq(LinkApplication.class), any(ListOptions.class)))
+            .thenReturn(Mono.error(new IllegalStateException("count unavailable")));
+
+        StepVerifier.create(service.isAvailable())
+            .expectError(LinkApplicationCapacityService.CapacityUnavailableException.class)
+            .verify();
+        StepVerifier.create(service.isAvailable())
+            .expectErrorMessage("count unavailable")
+            .verify();
+    }
+
+    private void givenSettings(int capacity) {
+        when(settingFetcher.fetch(LinkApplicationSettingsFetcher.SETTING_GROUP,
+            LinkApplicationSettings.class)).thenReturn(Mono.just(enabledSettings(capacity)));
+    }
+
+    private static LinkApplicationSettings enabledSettings(int capacity) {
+        var settings = new LinkApplicationSettings();
+        settings.setEnabled(true);
+        var security = new LinkApplicationSettings.Security();
+        security.setPendingCapacity(capacity);
+        settings.setSecurity(security);
+        return settings;
+    }
+
+    private static LinkApplication application(LinkApplication.Status status,
+        LinkApplication.OriginType originType) {
+        var application = new LinkApplication();
+        var metadata = new Metadata();
+        metadata.setName(status.name().toLowerCase() + "-" + originType.name().toLowerCase());
+        application.setMetadata(metadata);
+        var spec = new LinkApplication.LinkApplicationSpec();
+        spec.setStatus(status);
+        var origin = new LinkApplication.Origin();
+        origin.setType(originType);
+        spec.setOrigin(origin);
+        application.setSpec(spec);
+        return application;
+    }
+}

--- a/src/test/java/run/halo/links/service/LinkApplicationCreationCoordinatorTest.java
+++ b/src/test/java/run/halo/links/service/LinkApplicationCreationCoordinatorTest.java
@@ -84,4 +84,39 @@ class LinkApplicationCreationCoordinatorTest {
             .expectNext("third")
             .verifyComplete();
     }
+
+    @Test
+    void shouldNotSkipActiveKeyWhenMiddleWaiterIsCancelled() {
+        var coordinator = new LinkApplicationCreationCoordinator();
+        var firstMayFinish = Sinks.<Void>empty();
+        var firstStarted = new AtomicBoolean();
+        var secondStarted = new AtomicBoolean();
+        var thirdStarted = new AtomicBoolean();
+        var thirdResult = Sinks.<String>one();
+
+        coordinator.coordinate("key", () -> {
+            firstStarted.set(true);
+            return firstMayFinish.asMono().thenReturn("first");
+        }).subscribe();
+        assertThat(firstStarted).isTrue();
+
+        var secondSubscription = coordinator.coordinate("key", () -> {
+            secondStarted.set(true);
+            return Mono.just("second");
+        }).subscribe();
+        assertThat(secondStarted).isFalse();
+        secondSubscription.dispose();
+
+        coordinator.coordinate("key", () -> {
+            thirdStarted.set(true);
+            return Mono.just("third");
+        }).subscribe(thirdResult::tryEmitValue, thirdResult::tryEmitError);
+
+        assertThat(thirdStarted).isFalse();
+        firstMayFinish.tryEmitEmpty();
+
+        StepVerifier.create(thirdResult.asMono())
+            .expectNext("third")
+            .verifyComplete();
+    }
 }

--- a/src/test/java/run/halo/links/service/LinkApplicationCreationCoordinatorTest.java
+++ b/src/test/java/run/halo/links/service/LinkApplicationCreationCoordinatorTest.java
@@ -2,6 +2,7 @@ package run.halo.links.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
@@ -47,5 +48,40 @@ class LinkApplicationCreationCoordinatorTest {
             .verify();
 
         assertThat(coordinator.trackedKeyCount()).isZero();
+    }
+
+    @Test
+    void shouldNotSkipActiveCreationWhenMiddleWaiterIsCancelled() {
+        var coordinator = new LinkApplicationCreationCoordinator();
+        var firstMayFinish = Sinks.<Void>empty();
+        var firstStarted = new AtomicBoolean();
+        var secondStarted = new AtomicBoolean();
+        var thirdStarted = new AtomicBoolean();
+        var thirdResult = Sinks.<String>one();
+
+        coordinator.coordinateCreation(() -> {
+            firstStarted.set(true);
+            return firstMayFinish.asMono().thenReturn("first");
+        }).subscribe();
+        assertThat(firstStarted).isTrue();
+
+        var secondSubscription = coordinator.coordinateCreation(() -> {
+            secondStarted.set(true);
+            return Mono.just("second");
+        }).subscribe();
+        assertThat(secondStarted).isFalse();
+        secondSubscription.dispose();
+
+        coordinator.coordinateCreation(() -> {
+            thirdStarted.set(true);
+            return Mono.just("third");
+        }).subscribe(thirdResult::tryEmitValue, thirdResult::tryEmitError);
+
+        assertThat(thirdStarted).isFalse();
+        firstMayFinish.tryEmitEmpty();
+
+        StepVerifier.create(thirdResult.asMono())
+            .expectNext("third")
+            .verifyComplete();
     }
 }

--- a/src/test/java/run/halo/links/service/LinkApplicationServiceTest.java
+++ b/src/test/java/run/halo/links/service/LinkApplicationServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.math.BigDecimal;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -444,7 +445,7 @@ class LinkApplicationServiceTest {
         var settings = new LinkApplicationSettings();
         settings.setEnabled(true);
         var security = new LinkApplicationSettings.Security();
-        security.setPendingCapacity(capacity);
+        security.setPendingCapacity(BigDecimal.valueOf(capacity));
         settings.setSecurity(security);
         return settings;
     }

--- a/src/test/java/run/halo/links/service/LinkApplicationServiceTest.java
+++ b/src/test/java/run/halo/links/service/LinkApplicationServiceTest.java
@@ -7,6 +7,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,6 +23,9 @@ import reactor.test.StepVerifier;
 import run.halo.app.extension.ListOptions;
 import run.halo.app.extension.Metadata;
 import run.halo.app.extension.ReactiveExtensionClient;
+import run.halo.app.plugin.ReactiveSettingFetcher;
+import run.halo.links.dto.LinkApplicationSettings;
+import run.halo.links.endpoint.LinkApplicationSettingsFetcher;
 import run.halo.links.extension.Link;
 import run.halo.links.extension.LinkApplication;
 import run.halo.links.notification.LinkApplicationNotificationPublisher;
@@ -34,13 +39,21 @@ class LinkApplicationServiceTest {
     @Mock
     LinkApplicationNotificationPublisher notificationPublisher;
 
+    @Mock
+    ReactiveSettingFetcher settingFetcher;
+
     LinkApplicationService service;
 
     @BeforeEach
     void setUp() {
         lenient().when(notificationPublisher.publish(any())).thenReturn(Mono.empty());
+        lenient().when(settingFetcher.fetch(LinkApplicationSettingsFetcher.SETTING_GROUP,
+            LinkApplicationSettings.class)).thenReturn(Mono.just(enabledSettings(100)));
         service = new LinkApplicationService(client,
-            new LinkApplicationCreationCoordinator(), notificationPublisher);
+            new LinkApplicationCreationCoordinator(),
+            new LinkApplicationCapacityService(client,
+                new LinkApplicationSettingsFetcher(settingFetcher)),
+            notificationPublisher);
     }
 
     @Test
@@ -229,6 +242,105 @@ class LinkApplicationServiceTest {
     }
 
     @Test
+    void shouldRejectWhenPendingCapacityIsFull() {
+        givenCapacity(1);
+        givenExisting(List.of(), List.of(application("https://existing.example",
+            LinkApplication.Status.PENDING, LinkApplication.OriginType.COMMENT, "comment-a")));
+
+        StepVerifier.create(service.create(submission("https://new.example",
+                LinkApplication.OriginType.FORM, null)))
+            .assertNext(result -> assertThat(result.status())
+                .isEqualTo(LinkApplicationService.CreateStatus.CAPACITY_REACHED))
+            .verifyComplete();
+
+        verify(client, never()).create(any(LinkApplication.class));
+        verify(notificationPublisher, never()).publish(any());
+    }
+
+    @Test
+    void shouldReturnDuplicateBeforeCapacityReached() {
+        givenExisting(List.of(), List.of(application("https://example.com",
+            LinkApplication.Status.PENDING, LinkApplication.OriginType.FORM, null)));
+
+        verifyDuplicate(submission("https://example.com/",
+            LinkApplication.OriginType.COMMENT, "comment-a"));
+        verify(client, never()).create(any(LinkApplication.class));
+    }
+
+    @Test
+    void shouldCreateWhenExistingApplicationsDoNotConsumeCapacity() {
+        givenCapacity(1);
+        when(client.create(any(LinkApplication.class)))
+            .thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+
+        for (var status : List.of(
+            LinkApplication.Status.APPROVING,
+            LinkApplication.Status.APPROVED,
+            LinkApplication.Status.REJECTED
+        )) {
+            givenExisting(List.of(), List.of(application("https://existing.example",
+                status, LinkApplication.OriginType.COMMENT, "comment-" + status)));
+
+            StepVerifier.create(service.create(submission("https://" + status + ".example",
+                    LinkApplication.OriginType.FORM, null)))
+                .assertNext(result -> assertThat(result.status())
+                    .isEqualTo(LinkApplicationService.CreateStatus.CREATED))
+                .verifyComplete();
+        }
+    }
+
+    @Test
+    void shouldPropagateCapacityEvaluationFailure() {
+        when(client.listAll(
+            org.mockito.ArgumentMatchers.eq(Link.class),
+            any(ListOptions.class),
+            any(Sort.class)
+        )).thenReturn(Flux.empty());
+        when(client.listAll(
+            org.mockito.ArgumentMatchers.eq(LinkApplication.class),
+            any(ListOptions.class),
+            any(Sort.class)
+        )).thenReturn(Flux.error(new IllegalStateException("applications unavailable")));
+
+        StepVerifier.create(service.create(submission("https://example.com",
+                LinkApplication.OriginType.FORM, null)))
+            .expectErrorMessage("applications unavailable")
+            .verify();
+
+        verify(client, never()).create(any(LinkApplication.class));
+        verify(notificationPublisher, never()).publish(any());
+    }
+
+    @Test
+    void shouldReleaseCreationGateAfterFailure() {
+        when(client.listAll(
+            org.mockito.ArgumentMatchers.eq(Link.class),
+            any(ListOptions.class),
+            any(Sort.class)
+        )).thenReturn(Flux.empty());
+        when(client.listAll(
+            org.mockito.ArgumentMatchers.eq(LinkApplication.class),
+            any(ListOptions.class),
+            any(Sort.class)
+        )).thenReturn(
+            Flux.error(new IllegalStateException("applications unavailable")),
+            Flux.empty()
+        );
+        when(client.create(any(LinkApplication.class)))
+            .thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+
+        StepVerifier.create(service.create(submission("https://first.example",
+                LinkApplication.OriginType.FORM, null)))
+            .expectErrorMessage("applications unavailable")
+            .verify();
+        StepVerifier.create(service.create(submission("https://second.example",
+                LinkApplication.OriginType.FORM, null)))
+            .assertNext(result -> assertThat(result.status())
+                .isEqualTo(LinkApplicationService.CreateStatus.CREATED))
+            .verifyComplete();
+    }
+
+    @Test
     void shouldCoordinateConcurrentFormAndCommentCreation() {
         var stored = new CopyOnWriteArrayList<LinkApplication>();
         when(client.listAll(
@@ -261,6 +373,48 @@ class LinkApplicationServiceTest {
             .verifyComplete();
     }
 
+    @Test
+    void shouldKeepDifferentUrlConcurrencyWithinPendingCapacity() {
+        givenCapacity(2);
+        var stored = new CopyOnWriteArrayList<LinkApplication>();
+        stored.add(application("https://existing.example", LinkApplication.Status.PENDING,
+            LinkApplication.OriginType.FORM, null));
+        when(client.listAll(
+            org.mockito.ArgumentMatchers.eq(Link.class),
+            any(ListOptions.class),
+            any(Sort.class)
+        )).thenReturn(Flux.empty());
+        when(client.listAll(
+            org.mockito.ArgumentMatchers.eq(LinkApplication.class),
+            any(ListOptions.class),
+            any(Sort.class)
+        )).thenAnswer(ignored -> Flux.defer(() -> {
+            var snapshot = new ArrayList<>(stored);
+            return Mono.delay(Duration.ofMillis(50))
+                .thenMany(Flux.fromIterable(snapshot));
+        }));
+        when(client.create(any(LinkApplication.class))).thenAnswer(invocation -> {
+            LinkApplication application = invocation.getArgument(0);
+            stored.add(application);
+            return Mono.just(application);
+        });
+
+        var first = service.create(submission("https://first.example",
+            LinkApplication.OriginType.FORM, null));
+        var second = service.create(submission("https://second.example",
+            LinkApplication.OriginType.COMMENT, "comment-b"));
+
+        StepVerifier.create(Flux.merge(first, second)
+                .map(LinkApplicationService.CreateResult::status)
+                .collectList())
+            .assertNext(statuses -> assertThat(statuses)
+                .containsExactlyInAnyOrder(
+                    LinkApplicationService.CreateStatus.CREATED,
+                    LinkApplicationService.CreateStatus.CAPACITY_REACHED))
+            .verifyComplete();
+        assertThat(stored).hasSize(2);
+    }
+
     private void verifyDuplicate(LinkApplicationService.Submission submission) {
         StepVerifier.create(service.create(submission))
             .assertNext(result -> assertThat(result.status())
@@ -279,6 +433,20 @@ class LinkApplicationServiceTest {
             any(ListOptions.class),
             any(Sort.class)
         )).thenReturn(Flux.fromIterable(applications));
+    }
+
+    private void givenCapacity(int capacity) {
+        when(settingFetcher.fetch(LinkApplicationSettingsFetcher.SETTING_GROUP,
+            LinkApplicationSettings.class)).thenReturn(Mono.just(enabledSettings(capacity)));
+    }
+
+    private static LinkApplicationSettings enabledSettings(int capacity) {
+        var settings = new LinkApplicationSettings();
+        settings.setEnabled(true);
+        var security = new LinkApplicationSettings.Security();
+        security.setPendingCapacity(capacity);
+        settings.setSecurity(security);
+        return settings;
     }
 
     private static LinkApplicationService.Submission submission(String url,


### PR DESCRIPTION
## Summary

- add a configurable pending link application capacity under Application Security, defaulting to 100
- enforce one shared pending capacity across visitor submissions and Comment recognition
- serialize supported creation paths within one plugin instance to prevent concurrent requests from exceeding the limit
- skip Comment AI processing while capacity is full and preserve existing CAPTCHA, rate-limit, duplicate, and notification behavior
- document the capacity-full and temporarily-unavailable visitor redirects

## Notes

- only `PENDING` applications consume capacity
- lowering the capacity does not mutate existing applications
- duplicate detection remains higher priority than capacity exhaustion
- capacity evaluation failures fail closed without exposing submitted values
- the concurrency guarantee applies to supported creation paths within one plugin instance; distributed coordination and direct Extension API writes are outside this change
- no compatibility branch or migration is included because the link application feature has not been released

## Testing

- `./gradlew test`
- `./gradlew build`
- `openspec validate limit-pending-link-applications --strict`
- `git diff --check`