### PR TITLE
Fix intermittent startup failure during AI Foundation loading

### DIFF
--- a/src/main/java/run/halo/links/AiFoundationComponentsConfiguration.java
+++ b/src/main/java/run/halo/links/AiFoundationComponentsConfiguration.java
@@ -1,0 +1,24 @@
+package run.halo.links;
+
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import run.halo.links.endpoint.AiFoundationAvailableCondition;
+import run.halo.links.endpoint.LinkAiExtractEndpoint;
+import run.halo.links.recognition.CommentApplicationRecognitionProcessor;
+import run.halo.links.recognition.CommentApplicationRecognitionReconciler;
+import run.halo.links.service.ai.AiFoundationLinkAiService;
+
+/**
+ * Registers the complete AI Foundation integration as one conditional bean graph.
+ */
+@Configuration(proxyBeanMethods = false)
+@Conditional(AiFoundationAvailableCondition.class)
+@Import({
+    AiFoundationLinkAiService.class,
+    LinkAiExtractEndpoint.class,
+    CommentApplicationRecognitionProcessor.class,
+    CommentApplicationRecognitionReconciler.class
+})
+public class AiFoundationComponentsConfiguration {
+}

--- a/src/main/java/run/halo/links/endpoint/LinkAiExtractEndpoint.java
+++ b/src/main/java/run/halo/links/endpoint/LinkAiExtractEndpoint.java
@@ -6,9 +6,7 @@ import static org.springdoc.webflux.core.fn.SpringdocRouteBuilder.route;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.annotation.Conditional;
 import org.springframework.http.HttpStatus;
-import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.reactive.function.server.ServerResponse;
@@ -24,14 +22,10 @@ import java.util.Map;
 
 /**
  * Console endpoint for AI-powered comment analysis.
- * This endpoint is registered only when the conditional AI adapter is available.
- * If AI Foundation is missing, this bean is skipped and the status endpoint in
- * {@link LinkAiStatusEndpoint} remains functional.
+ * Registered with the complete conditional AI integration when AI Foundation is available.
  */
 @Slf4j
-@Component
 @RequiredArgsConstructor
-@Conditional(AiFoundationAvailableCondition.class)
 public class LinkAiExtractEndpoint implements CustomEndpoint {
 
     private final LinkAiService aiService;

--- a/src/main/java/run/halo/links/recognition/CommentApplicationRecognitionProcessor.java
+++ b/src/main/java/run/halo/links/recognition/CommentApplicationRecognitionProcessor.java
@@ -8,8 +8,6 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.context.annotation.Conditional;
-import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 import run.halo.app.core.extension.Plugin;
 import run.halo.app.core.extension.content.Comment;
@@ -23,7 +21,6 @@ import run.halo.app.plugin.ReactiveSettingFetcher;
 import run.halo.links.dto.LinkApplicationSettings;
 import run.halo.links.dto.LinkCommentRecognitionRequest;
 import run.halo.links.dto.LinkCommentRecognitionResult;
-import run.halo.links.endpoint.AiFoundationAvailableCondition;
 import run.halo.links.endpoint.LinkApplicationSettingsFetcher;
 import run.halo.links.extension.LinkApplication;
 import run.halo.links.route.LinkBaseSettings;
@@ -35,9 +32,7 @@ import run.halo.links.service.ai.LinkAiService;
 /**
  * Converts one eligible new Comment into a pending LinkApplication when AI recognizes it.
  */
-@Component
 @RequiredArgsConstructor
-@Conditional(AiFoundationAvailableCondition.class)
 @Slf4j
 public class CommentApplicationRecognitionProcessor {
 

--- a/src/main/java/run/halo/links/recognition/CommentApplicationRecognitionReconciler.java
+++ b/src/main/java/run/halo/links/recognition/CommentApplicationRecognitionReconciler.java
@@ -3,22 +3,17 @@ package run.halo.links.recognition;
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.annotation.Conditional;
-import org.springframework.stereotype.Component;
 import run.halo.app.core.extension.content.Comment;
 import run.halo.app.extension.ExtensionClient;
 import run.halo.app.extension.controller.Controller;
 import run.halo.app.extension.controller.ControllerBuilder;
 import run.halo.app.extension.controller.Reconciler;
-import run.halo.links.endpoint.AiFoundationAvailableCondition;
 
 /**
  * Add-event-only controller for automatic comment application recognition.
  */
 @Slf4j
-@Component
 @RequiredArgsConstructor
-@Conditional(AiFoundationAvailableCondition.class)
 public class CommentApplicationRecognitionReconciler
     implements Reconciler<Reconciler.Request> {
 

--- a/src/main/java/run/halo/links/service/ai/AiFoundationLinkAiService.java
+++ b/src/main/java/run/halo/links/service/ai/AiFoundationLinkAiService.java
@@ -5,8 +5,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Conditional;
-import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 import run.halo.aifoundation.AiModelService;
 import run.halo.aifoundation.chat.GenerateTextRequest;
@@ -19,14 +17,11 @@ import run.halo.app.plugin.extensionpoint.ExtensionGetter;
 import run.halo.links.dto.LinkCommentExtractionResult;
 import run.halo.links.dto.LinkCommentRecognitionRequest;
 import run.halo.links.dto.LinkCommentRecognitionResult;
-import run.halo.links.endpoint.AiFoundationAvailableCondition;
 
 /**
  * AI Foundation implementation isolated behind an optional classpath condition.
  */
-@Component
 @RequiredArgsConstructor
-@Conditional(AiFoundationAvailableCondition.class)
 public class AiFoundationLinkAiService implements LinkAiService {
 
     static final Duration RECOGNITION_TIMEOUT = Duration.ofSeconds(30);

--- a/src/test/java/run/halo/links/endpoint/AiFoundationAvailabilityTest.java
+++ b/src/test/java/run/halo/links/endpoint/AiFoundationAvailabilityTest.java
@@ -1,23 +1,43 @@
 package run.halo.links.endpoint;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.stereotype.Component;
+import run.halo.app.extension.ExtensionClient;
+import run.halo.app.extension.ReactiveExtensionClient;
+import run.halo.app.plugin.PluginContext;
+import run.halo.app.plugin.ReactiveSettingFetcher;
+import run.halo.app.plugin.extensionpoint.ExtensionGetter;
+import run.halo.links.AiFoundationComponentsConfiguration;
 import run.halo.links.recognition.CommentApplicationRecognitionProcessor;
 import run.halo.links.recognition.CommentApplicationRecognitionReconciler;
+import run.halo.links.service.LinkApplicationCapacityService;
+import run.halo.links.service.LinkApplicationService;
 import run.halo.links.service.ai.AiFoundationLinkAiService;
 
 class AiFoundationAvailabilityTest {
+
+    private static final String AI_MODEL_SERVICE_CLASS =
+        "run.halo.aifoundation.AiModelService";
+    private static final List<Class<?>> AI_COMPONENT_TYPES = List.of(
+        AiFoundationLinkAiService.class,
+        LinkAiExtractEndpoint.class,
+        AiFoundationComponentsConfiguration.class
+    );
 
     @Test
     void shouldStartContextWithoutRegisteringAiComponentsWhenApiIsAbsent() {
         new ApplicationContextRunner()
             .withClassLoader(new FilteredClassLoader("run.halo.aifoundation"))
-            .withUserConfiguration(ConditionalAiConfiguration.class)
+            .withUserConfiguration(AiFoundationComponentsConfiguration.class)
             .run(context -> {
                 assertThat(context.getStartupFailure()).isNull();
                 assertThat(context).doesNotHaveBean(AiFoundationLinkAiService.class);
@@ -34,13 +54,65 @@ class AiFoundationAvailabilityTest {
         assertThat(AiFoundationAvailability.isAvailable()).isTrue();
     }
 
-    @Configuration(proxyBeanMethods = false)
-    @Import({
-        AiFoundationLinkAiService.class,
-        LinkAiExtractEndpoint.class,
-        CommentApplicationRecognitionProcessor.class,
-        CommentApplicationRecognitionReconciler.class
-    })
-    static class ConditionalAiConfiguration {
+    @Test
+    void shouldRegisterCompleteAiComponentGraphWhenApiIsAvailable() {
+        new ApplicationContextRunner()
+            .withUserConfiguration(AiFoundationComponentsConfiguration.class)
+            .withBean(ExtensionGetter.class, () -> mock(ExtensionGetter.class))
+            .withBean(LinkAiSettingsFetcher.class, () -> mock(LinkAiSettingsFetcher.class))
+            .withBean(LinkApplicationSettingsFetcher.class,
+                () -> mock(LinkApplicationSettingsFetcher.class))
+            .withBean(LinkApplicationService.class, () -> mock(LinkApplicationService.class))
+            .withBean(LinkApplicationCapacityService.class,
+                () -> mock(LinkApplicationCapacityService.class))
+            .withBean(ReactiveExtensionClient.class, () -> mock(ReactiveExtensionClient.class))
+            .withBean(ReactiveSettingFetcher.class, () -> mock(ReactiveSettingFetcher.class))
+            .withBean(PluginContext.class, () -> mock(PluginContext.class))
+            .withBean(ExtensionClient.class, () -> mock(ExtensionClient.class))
+            .run(context -> {
+                assertThat(context).hasNotFailed();
+                assertThat(context).hasSingleBean(AiFoundationLinkAiService.class);
+                assertThat(context).hasSingleBean(LinkAiExtractEndpoint.class);
+                assertThat(context).hasSingleBean(
+                    CommentApplicationRecognitionProcessor.class);
+                assertThat(context).hasSingleBean(
+                    CommentApplicationRecognitionReconciler.class);
+            });
     }
+
+    @Test
+    void shouldNotPartiallyRegisterAiComponentsWhenApiAppearsDuringRegistration() {
+        var lookups = new AtomicInteger();
+        var changingClassLoader = new ClassLoader(getClass().getClassLoader()) {
+            @Override
+            protected Class<?> loadClass(String name, boolean resolve)
+                throws ClassNotFoundException {
+                if (AI_MODEL_SERVICE_CLASS.equals(name) && lookups.getAndIncrement() == 0) {
+                    throw new ClassNotFoundException(name);
+                }
+                return super.loadClass(name, resolve);
+            }
+        };
+
+        new ApplicationContextRunner()
+            .withClassLoader(changingClassLoader)
+            .withInitializer(context -> registerIndexedAiComponents(
+                (GenericApplicationContext) context))
+            .run(context -> {
+                assertThat(context).hasNotFailed();
+                assertThat(context).doesNotHaveBean(AiFoundationLinkAiService.class);
+                assertThat(context).doesNotHaveBean(LinkAiExtractEndpoint.class);
+                assertThat(context).doesNotHaveBean(
+                    CommentApplicationRecognitionProcessor.class);
+                assertThat(context).doesNotHaveBean(
+                    CommentApplicationRecognitionReconciler.class);
+            });
+    }
+
+    private static void registerIndexedAiComponents(GenericApplicationContext context) {
+        AI_COMPONENT_TYPES.stream()
+            .filter(type -> AnnotatedElementUtils.hasAnnotation(type, Component.class))
+            .forEach(context::registerBean);
+    }
+
 }


### PR DESCRIPTION
## What changed

- Register the AI Foundation integration through one conditional configuration.
- Import the AI service, extraction endpoint, recognition processor, and reconciler as a single bean graph.
- Add context regression tests for missing, available, and mid-registration dependency states.

## Why

PluginLinks may start while the optional AI Foundation plugin is being loaded. Because each AI component previously evaluated the availability condition independently, the service could be skipped while the endpoint was registered. Spring then failed to create `LinkAiExtractEndpoint` because no `LinkAiService` bean was available.

## Reproduction and verification

A deterministic class-loader regression test makes the AI Foundation API unavailable for the first component registration lookup and available for later lookups. Before the fix, this reproduced the `NoSuchBeanDefinitionException`; after the fix, the context starts without a partial AI bean graph.

A Halo 2.25.2 runtime validation also loaded AI Foundation while the PluginLinks application context was refreshing. PluginLinks started successfully, then reloaded after the optional dependency became available and started the recognition reconciler.

## Testing

- `./gradlew test --tests run.halo.links.endpoint.AiFoundationAvailabilityTest`
- `./gradlew test`
- `./gradlew build`
