### PR TITLE
Clean up RSS data when unsubscribing

### DIFF
--- a/console/src/components/LinkEditingModal.vue
+++ b/console/src/components/LinkEditingModal.vue
@@ -4,7 +4,9 @@ import type { JsonPatchInner, Link } from "@/api/generated";
 import { startInitialLinkFeedRefresh } from "@/composables/link-feed-initial-refresh";
 import { startLinkVerification } from "@/composables/link-verification";
 import { QK_LINK_GROUPS } from "@/composables/use-group-fetch";
+import { QK_LINK_FEED_HIDDEN_ITEMS, QK_LINK_FEED_ITEMS } from "@/composables/use-link-feed";
 import { invalidateLinkFeedItemSummary } from "@/composables/use-link-feed-item-summary";
+import { invalidateLinkFeedUnreadSummary } from "@/composables/use-link-feed-unread-summary";
 import { QK_GROUPS_WITH_LINKS, QK_RSS_GROUPS_WITH_LINKS } from "@/composables/use-link-fetch";
 import type { LinkFormState } from "@/types";
 import { Dialog, Toast, VButton, VModal, VSpace } from "@halo-dev/components";
@@ -109,6 +111,12 @@ const { mutate, isPending } = useMutation({
     queryClient.invalidateQueries({ queryKey: [QK_LINK_GROUPS] });
     queryClient.invalidateQueries({ queryKey: [QK_GROUPS_WITH_LINKS] });
     queryClient.invalidateQueries({ queryKey: [QK_RSS_GROUPS_WITH_LINKS] });
+    if (isUnsubscribe(data)) {
+      queryClient.invalidateQueries({ queryKey: [QK_LINK_FEED_ITEMS] });
+      queryClient.invalidateQueries({ queryKey: [QK_LINK_FEED_HIDDEN_ITEMS] });
+      invalidateLinkFeedUnreadSummary(queryClient);
+      invalidateLinkFeedItemSummary(queryClient);
+    }
     startLinkVerification({ request: { names: [props.link.metadata.name] }, queryClient });
     if (shouldRefreshFeedAfterSave(data)) {
       startInitialLinkFeedRefresh({ linkName: props.link.metadata.name, queryClient });
@@ -117,7 +125,20 @@ const { mutate, isPending } = useMutation({
 });
 
 function onSubmit(data: LinkFormState) {
+  if (isUnsubscribe(data)) {
+    Dialog.warning({
+      title: "是否确认关闭 RSS 订阅？",
+      description: "关闭后将永久删除该链接的全部 RSS 缓存，包括收藏、稍后阅读和已隐藏的文章，且无法恢复。",
+      confirmType: "danger",
+      onConfirm: () => mutate(data),
+    });
+    return;
+  }
   mutate(data);
+}
+
+function isUnsubscribe(data: LinkFormState) {
+  return Boolean(props.link.spec?.rss?.enabled && !data.rss?.enabled);
 }
 
 function linkRssSpec(data: LinkFormState) {

--- a/console/src/components/__tests__/LinkEditingModal.test.ts
+++ b/console/src/components/__tests__/LinkEditingModal.test.ts
@@ -1,0 +1,165 @@
+import type { Link } from "@/api/generated";
+import { QK_LINK_FEED_HIDDEN_ITEMS, QK_LINK_FEED_ITEMS } from "@/composables/use-link-feed";
+import { QK_LINK_FEED_ITEM_SUMMARY } from "@/composables/use-link-feed-item-summary";
+import { QK_LINK_FEED_UNREAD_SUMMARY } from "@/composables/use-link-feed-unread-summary";
+import type { LinkFormState } from "@/types";
+import { Dialog } from "@halo-dev/components";
+import { beforeEach, describe, expect, it, rstest } from "@rstest/core";
+import { VueQueryPlugin } from "@tanstack/vue-query";
+import { flushPromises, mount, type VueWrapper } from "@vue/test-utils";
+import { createFeedTestQueryClient } from "../../composables/link-feed-test-utils";
+import LinkEditingModal from "../LinkEditingModal.vue";
+
+const componentMocks = rstest.hoisted(() => ({
+  deleteLink: rstest.fn(),
+  patchLink: rstest.fn(),
+  startInitialLinkFeedRefresh: rstest.fn(),
+  startLinkVerification: rstest.fn(),
+}));
+
+rstest.mock("@/api", () => ({
+  linksCoreApiClient: {
+    link: {
+      deleteLink: componentMocks.deleteLink,
+      patchLink: componentMocks.patchLink,
+    },
+  },
+}));
+
+rstest.mock("@/composables/link-feed-initial-refresh", () => ({
+  startInitialLinkFeedRefresh: componentMocks.startInitialLinkFeedRefresh,
+}));
+
+rstest.mock("@/composables/link-verification", () => ({
+  startLinkVerification: componentMocks.startLinkVerification,
+}));
+
+const dialogSpy = rstest.spyOn(Dialog, "warning");
+
+describe("LinkEditingModal RSS unsubscribe", () => {
+  beforeEach(() => {
+    componentMocks.patchLink.mockResolvedValue({ data: {} });
+  });
+
+  it("confirms an enabled-to-disabled transition before saving", async () => {
+    const { wrapper } = mountModal(link(true));
+
+    submitForm(wrapper, formState(false));
+    await flushPromises();
+
+    expect(dialogSpy).toHaveBeenCalledTimes(1);
+    const options = dialogSpy.mock.calls[0][0] as {
+      description?: string;
+      onConfirm?: () => Promise<void> | void;
+    };
+    expect(options.description).toContain("收藏、稍后阅读和已隐藏");
+    expect(options.description).toContain("永久删除");
+    expect(componentMocks.patchLink).not.toHaveBeenCalled();
+
+    await options.onConfirm?.();
+    await flushPromises();
+
+    expect(componentMocks.patchLink).toHaveBeenCalledTimes(1);
+    expect(componentMocks.patchLink).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "link-a",
+        jsonPatchInner: expect.arrayContaining([
+          {
+            op: "add",
+            path: "/spec/rss",
+            value: {
+              enabled: false,
+              feedUrls: ["https://example.com/feed.xml"],
+            },
+          },
+        ]),
+      }),
+    );
+  });
+
+  it("does not save when unsubscribe confirmation is cancelled", async () => {
+    const { wrapper } = mountModal(link(true));
+
+    submitForm(wrapper, formState(false));
+    await flushPromises();
+
+    expect(dialogSpy).toHaveBeenCalledTimes(1);
+    expect(componentMocks.patchLink).not.toHaveBeenCalled();
+  });
+
+  it("does not confirm edits to an already disabled subscription", async () => {
+    const { wrapper } = mountModal(link(false));
+
+    submitForm(wrapper, formState(false));
+    await flushPromises();
+
+    expect(dialogSpy).not.toHaveBeenCalled();
+    expect(componentMocks.patchLink).toHaveBeenCalledTimes(1);
+  });
+
+  it("invalidates all RSS data queries after confirmed unsubscribe", async () => {
+    const { wrapper, invalidateSpy } = mountModal(link(true));
+
+    submitForm(wrapper, formState(false));
+    await flushPromises();
+    const options = dialogSpy.mock.calls[0][0] as { onConfirm?: () => Promise<void> | void };
+    await options.onConfirm?.();
+    await flushPromises();
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: [QK_LINK_FEED_ITEMS] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: [QK_LINK_FEED_HIDDEN_ITEMS] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: [QK_LINK_FEED_UNREAD_SUMMARY] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: [QK_LINK_FEED_ITEM_SUMMARY] });
+  });
+});
+
+function mountModal(linkValue: Link) {
+  const queryClient = createFeedTestQueryClient();
+  const invalidateSpy = rstest.spyOn(queryClient, "invalidateQueries");
+  const wrapper = mount(LinkEditingModal, {
+    props: { link: linkValue },
+    global: {
+      plugins: [[VueQueryPlugin, { queryClient }]],
+      stubs: {
+        LinkForm: {
+          name: "LinkForm",
+          emits: ["submit"],
+          template: "<div />",
+        },
+      },
+    },
+  });
+  return { wrapper, invalidateSpy };
+}
+
+function submitForm(wrapper: VueWrapper, data: LinkFormState) {
+  wrapper.findComponent({ name: "LinkForm" }).vm.$emit("submit", data);
+}
+
+function link(rssEnabled: boolean): Link {
+  return {
+    metadata: {
+      name: "link-a",
+      annotations: {},
+    },
+    spec: {
+      url: "https://example.com",
+      displayName: "Example",
+      rss: {
+        enabled: rssEnabled,
+        feedUrls: ["https://example.com/feed.xml"],
+      },
+    },
+  } as Link;
+}
+
+function formState(rssEnabled: boolean): LinkFormState {
+  return {
+    url: "https://example.com",
+    displayName: "Example",
+    rss: {
+      enabled: rssEnabled,
+      feedUrls: ["https://example.com/feed.xml"],
+    },
+  };
+}

--- a/openspec/changes/archive/2026-08-12-cleanup-rss-cache-on-unsubscribe/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-12-cleanup-rss-cache-on-unsubscribe/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-12

--- a/openspec/changes/archive/2026-08-12-cleanup-rss-cache-on-unsubscribe/design.md
+++ b/openspec/changes/archive/2026-08-12-cleanup-rss-cache-on-unsubscribe/design.md
@@ -53,6 +53,10 @@ a refresh that fetched the Link while enabled and completes after it has been di
    leaves `status.rss` clear, and does not publish the stale refresh result. This second guard makes
    the final state independent of whether reconciliation or the refresh finishes first.
 
+   Cache writes and cleanup are serialized by Link name across refresh and reconciliation. This
+   ensures cleanup based on a disabled Link snapshot finishes before a newly re-enabled subscription
+   can write its initial cache, without serializing operations for unrelated Links.
+
    **Alternative considered:** rely only on the next reconciliation event. That is eventually
    consistent in the common case, but a refresh could recreate rows after cleanup and then fail to
    update the Link, leaving no later event guaranteed to remove them.

--- a/openspec/changes/archive/2026-08-12-cleanup-rss-cache-on-unsubscribe/design.md
+++ b/openspec/changes/archive/2026-08-12-cleanup-rss-cache-on-unsubscribe/design.md
@@ -1,0 +1,100 @@
+## Context
+
+RSS feed items are operational cache records keyed by Link metadata name and stored in the
+plugin-local SQLite database. A Link with `spec.rss.enabled=false` is excluded from scheduled and
+manual refreshes, but its existing items and `status.rss` remain. Because Console source resolution
+only loads enabled subscriptions, those items are then rendered as belonging to a deleted link.
+
+Link deletion already uses `LinkReconciler` and a finalizer to call the store-level
+`deleteByLinkName` operation. Unsubscribing is different from deletion: the Link and its feed URL
+configuration remain, while only operational RSS data is discarded. Cleanup must also account for
+a refresh that fetched the Link while enabled and completes after it has been disabled.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Remove every cached feed item and all RSS runtime status when a Link is no longer subscribed.
+- Apply cleanup independently of whether the Link was edited through Console or the Extension API.
+- Preserve feed URLs on an explicitly disabled RSS configuration for convenient re-enablement.
+- Ensure an in-flight refresh cannot leave cache records or runtime status after unsubscribe.
+- Make the destructive behavior explicit in Console and refresh affected client-side queries.
+
+**Non-Goals:**
+
+- Do not add per-item physical deletion; hidden items remain the mechanism for excluding individual
+  entries while a subscription is enabled.
+- Do not add a custom unsubscribe endpoint, generated API client operation, or database migration.
+- Do not preserve favorite, read-later, hidden, or read state after the owning subscription ends.
+- Do not remove feed URLs merely because RSS tracking is disabled.
+
+## Decisions
+
+1. Treat current desired state as authoritative in Link reconciliation.
+
+   For every live Link whose RSS configuration is absent or not enabled, reconciliation deletes
+   cached items by metadata name and clears `status.rss`. This is based on current state rather than
+   detecting a specific true-to-false transition, so startup synchronization also repairs stale
+   cache created before this change and direct Extension API writes receive the same behavior.
+
+   Cleanup remains idempotent. Cache deletion happens before status is cleared; if storage cleanup
+   fails, the reconciler must not persist an apparently clean status. Existing deletion-finalizer
+   behavior remains unchanged.
+
+   **Alternative considered:** perform cleanup only in `LinkEditingModal`. This would provide a
+   simpler immediate UI flow but would miss non-Console writers and would not repair existing stale
+   data.
+
+2. Recheck subscription state when a refresh completes.
+
+   A refresh may pass its initial enabled check, perform network and SQLite work, and then race with
+   unsubscribe reconciliation. Before applying success or failure status, refresh completion must
+   fetch the latest Link. If that Link is no longer subscribed, it performs the same cache cleanup,
+   leaves `status.rss` clear, and does not publish the stale refresh result. This second guard makes
+   the final state independent of whether reconciliation or the refresh finishes first.
+
+   **Alternative considered:** rely only on the next reconciliation event. That is eventually
+   consistent in the common case, but a refresh could recreate rows after cleanup and then fail to
+   update the Link, leaving no later event guaranteed to remove them.
+
+3. Preserve configuration but discard all operational RSS state.
+
+   When `spec.rss` remains present with `enabled=false`, `feedUrls` remain unchanged. Cleanup removes
+   all rows for the Link, regardless of read, favorite, read-later, or hidden flags, and sets
+   `status.rss` to null. Re-enabling therefore starts from an empty cache and the existing initial
+   refresh flow repopulates current upstream items without stale validators or counts.
+
+4. Confirm only a real unsubscribe transition in Console.
+
+   Saving a Link that changes RSS from enabled to disabled requires confirmation describing the
+   irreversible removal of all cached and saved RSS items. Cancelling the confirmation performs no
+   patch. Successful unsubscribe invalidates Link subscription queries, feed item lists, unread
+   summaries, and the unified item summary so later views reload backend state. Editing an already
+   disabled Link does not repeatedly prompt.
+
+   **Alternative considered:** confirm immediately when the checkbox is cleared. Confirming at save
+   time keeps unsaved form interaction reversible and matches when the destructive state change is
+   actually submitted.
+
+## Risks / Trade-offs
+
+- [Risk] Reconciliation is asynchronous relative to the core Link patch response, so Console may
+  briefly observe old aggregate counts. → Invalidate all affected queries after save and make the
+  backend lifecycle, rather than transient UI state, the source of truth.
+- [Risk] A large cache deletion can occupy the synchronous reconciler path. → Reuse the indexed
+  `deleteByLinkName` SQLite operation and keep cleanup scoped to one Link.
+- [Risk] Storage failure leaves an unsubscribed Link with stale operational data. → Delete cache
+  first, do not clear status on failure, and allow later reconciliation or startup sync to retry.
+- [Risk] Users may expect favorites or read-later items to survive. → State explicitly in the
+  confirmation that all cached RSS data is permanently removed.
+
+## Migration Plan
+
+No schema or data migration is required. On deployment, controller startup synchronization visits
+existing Links and removes stale RSS data from Links that are already unsubscribed. Rollback does
+not require data conversion, but data removed by unsubscribe cannot be restored except by enabling
+RSS and fetching it again from upstream sources.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-08-12-cleanup-rss-cache-on-unsubscribe/proposal.md
+++ b/openspec/changes/archive/2026-08-12-cleanup-rss-cache-on-unsubscribe/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+Disabling RSS tracking currently stops future refreshes but leaves the link's cached feed items in
+SQLite. Those orphaned items remain in aggregate RSS views and appear to come from a deleted link,
+even though the Link itself still exists.
+
+## What Changes
+
+- Treat changing a Link from an enabled RSS subscription to a disabled or absent RSS configuration
+  as an unsubscribe lifecycle event.
+- Delete all cached feed items owned by the unsubscribed Link, including hidden, favorite, and
+  read-later items, and clear its `status.rss` runtime state.
+- Preserve configured feed URLs while RSS is disabled so the subscription can be enabled again.
+- Prevent a refresh already in progress from restoring feed items or RSS status after the Link has
+  been unsubscribed.
+- Warn Console users that unsubscribing permanently removes cached RSS data and refresh affected RSS
+  queries after a successful save.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `link-rss-feed`: Define unsubscribe cleanup semantics, including cached item removal, RSS status
+  cleanup, preservation of feed URL configuration, and in-flight refresh handling.
+
+## Impact
+
+- Backend Link reconciliation and RSS refresh completion behavior.
+- Plugin-local SQLite feed item data and Link `status.rss` state.
+- Console link editing confirmation and Vue Query cache invalidation.
+- No new API endpoint, generated client change, database migration, or dependency is required.

--- a/openspec/changes/archive/2026-08-12-cleanup-rss-cache-on-unsubscribe/specs/link-rss-feed/spec.md
+++ b/openspec/changes/archive/2026-08-12-cleanup-rss-cache-on-unsubscribe/specs/link-rss-feed/spec.md
@@ -42,6 +42,11 @@ as an enabled RSS subscription.
 - **THEN** the existing initial refresh flow fetches the subscription into an empty Link cache
 - **AND** the system derives new RSS runtime status from that refresh
 
+#### Scenario: Subscription is re-enabled while cleanup is completing
+- **WHEN** an unsubscribed Link is enabled again while its previous RSS cleanup is still running
+- **THEN** cleanup completes before the re-enabled subscription writes new cached feed items
+- **AND** cleanup does not remove items or runtime status produced by the new refresh
+
 ### Requirement: Console RSS unsubscribe confirmation
 The Console SHALL warn administrators before saving a Link change that ends an enabled RSS
 subscription.

--- a/openspec/changes/archive/2026-08-12-cleanup-rss-cache-on-unsubscribe/specs/link-rss-feed/spec.md
+++ b/openspec/changes/archive/2026-08-12-cleanup-rss-cache-on-unsubscribe/specs/link-rss-feed/spec.md
@@ -1,0 +1,63 @@
+## ADDED Requirements
+
+### Requirement: RSS unsubscribe data cleanup
+The system SHALL remove operational RSS data owned by a Link when that Link is no longer configured
+as an enabled RSS subscription.
+
+#### Scenario: User disables an enabled subscription
+- **WHEN** a Link with `spec.rss.enabled` set to `true` is updated so that
+  `spec.rss.enabled` is `false`
+- **THEN** the system excludes that Link from subsequent RSS refreshes
+- **AND** the system removes every cached feed item whose link name matches that Link
+- **AND** the system clears the Link's `status.rss`
+- **AND** the system preserves the Link's configured `spec.rss.feedUrls`
+
+#### Scenario: RSS configuration is removed
+- **WHEN** an enabled Link's `spec.rss` configuration is removed
+- **THEN** the system removes every cached feed item whose link name matches that Link
+- **AND** the system clears the Link's `status.rss`
+
+#### Scenario: Saved and hidden items do not survive unsubscribe
+- **WHEN** an unsubscribed Link owns cached feed items marked as read, favorite, read-later, or hidden
+- **THEN** the system removes those items together with the rest of that Link's feed cache
+
+#### Scenario: Existing unsubscribed Link has stale data
+- **WHEN** startup reconciliation observes a Link that is not an enabled RSS subscription and that
+  Link still has cached feed items or `status.rss`
+- **THEN** the system removes the stale cached items and clears `status.rss`
+
+#### Scenario: Unsubscribe cleanup fails
+- **WHEN** the feed item store fails while cleaning an unsubscribed Link
+- **THEN** the system does not clear the Link's `status.rss` as though cleanup succeeded
+- **AND** a later reconciliation can retry the idempotent cleanup
+
+#### Scenario: Refresh completes after unsubscribe
+- **WHEN** an RSS refresh begins while a Link is enabled and the Link is unsubscribed before that
+  refresh completes
+- **THEN** the refresh does not leave cached feed items for that Link
+- **AND** the refresh does not restore `status.rss`
+
+#### Scenario: Subscription is enabled again
+- **WHEN** a previously unsubscribed Link is enabled again with one or more feed URLs
+- **THEN** the existing initial refresh flow fetches the subscription into an empty Link cache
+- **AND** the system derives new RSS runtime status from that refresh
+
+### Requirement: Console RSS unsubscribe confirmation
+The Console SHALL warn administrators before saving a Link change that ends an enabled RSS
+subscription.
+
+#### Scenario: Administrator confirms unsubscribe
+- **WHEN** an administrator saves a Link after changing RSS from enabled to disabled
+- **THEN** the Console asks for confirmation that all cached RSS items, including saved and hidden
+  items, will be permanently removed
+- **AND** after confirmation the Console submits the Link update
+- **AND** after a successful update the Console invalidates affected Link, feed item, unread, and
+  item-summary queries
+
+#### Scenario: Administrator cancels unsubscribe
+- **WHEN** an administrator cancels the RSS unsubscribe confirmation
+- **THEN** the Console does not submit the Link update
+
+#### Scenario: Administrator edits an already disabled subscription
+- **WHEN** an administrator saves other changes to a Link whose RSS subscription was already disabled
+- **THEN** the Console does not show the unsubscribe confirmation

--- a/openspec/changes/archive/2026-08-12-cleanup-rss-cache-on-unsubscribe/tasks.md
+++ b/openspec/changes/archive/2026-08-12-cleanup-rss-cache-on-unsubscribe/tasks.md
@@ -1,0 +1,26 @@
+## 1. Backend unsubscribe lifecycle
+
+- [x] 1.1 Add `LinkReconciler` tests for disabled and absent RSS configuration, stale cache and
+  status cleanup, feed URL preservation, idempotent startup repair, and storage-cleanup failure.
+- [x] 1.2 Extend Link reconciliation to delete all feed items before clearing `status.rss` for live
+  Links that are not enabled subscriptions, without changing Link deletion finalizer behavior.
+- [x] 1.3 Add RSS service tests that pause an enabled refresh, disable or remove RSS before refresh
+  completion, and verify both successful and failed refresh paths leave no cache or RSS status.
+- [x] 1.4 Recheck the latest Link subscription state before publishing refresh success or failure;
+  run unsubscribe cleanup and discard the stale refresh result when RSS is no longer enabled.
+
+## 2. Console unsubscribe flow
+
+- [x] 2.1 Add colocated `LinkEditingModal` tests for confirmed unsubscribe, cancelled unsubscribe,
+  edits to an already disabled Link, and invalidation of Link/feed/unread/item-summary queries.
+- [x] 2.2 Add the irreversible-data warning to the enabled-to-disabled save transition and refresh
+  all affected Vue Query caches after a confirmed successful update.
+
+## 3. Verification
+
+- [x] 3.1 Run focused backend reconciliation, RSS service, and SQLite store tests, then run the full
+  Gradle test suite.
+- [x] 3.2 Run Console unit tests, type checking, linting, and Prettier verification with the pinned
+  pnpm toolchain.
+- [x] 3.3 Run the production build, `git diff --check`, and targeted OpenSpec validation for
+  `cleanup-rss-cache-on-unsubscribe` and `link-rss-feed`.

--- a/openspec/changes/archive/2026-08-12-cleanup-rss-cache-on-unsubscribe/tasks.md
+++ b/openspec/changes/archive/2026-08-12-cleanup-rss-cache-on-unsubscribe/tasks.md
@@ -6,6 +6,7 @@
   Links that are not enabled subscriptions, without changing Link deletion finalizer behavior.
 - [x] 1.3 Add RSS service tests that pause an enabled refresh, disable or remove RSS before refresh
   completion, and verify both successful and failed refresh paths leave no cache or RSS status.
+  Cover immediate re-enablement while cleanup is still running.
 - [x] 1.4 Recheck the latest Link subscription state before publishing refresh success or failure;
   run unsubscribe cleanup and discard the stale refresh result when RSS is no longer enabled.
 

--- a/openspec/specs/link-rss-feed/spec.md
+++ b/openspec/specs/link-rss-feed/spec.md
@@ -1131,6 +1131,11 @@ as an enabled RSS subscription.
 - **THEN** the existing initial refresh flow fetches the subscription into an empty Link cache
 - **AND** the system derives new RSS runtime status from that refresh
 
+#### Scenario: Subscription is re-enabled while cleanup is completing
+- **WHEN** an unsubscribed Link is enabled again while its previous RSS cleanup is still running
+- **THEN** cleanup completes before the re-enabled subscription writes new cached feed items
+- **AND** cleanup does not remove items or runtime status produced by the new refresh
+
 ### Requirement: Console RSS unsubscribe confirmation
 The Console SHALL warn administrators before saving a Link change that ends an enabled RSS
 subscription.

--- a/openspec/specs/link-rss-feed/spec.md
+++ b/openspec/specs/link-rss-feed/spec.md
@@ -1088,3 +1088,65 @@ counts for hidden, favorite, and read-later cached RSS/Atom feed items without l
 - **WHEN** a user with `plugin:links:view` requests the item count summary
 - **THEN** the request is authorized
 - **AND** the operation does not require `plugin:links:manage`
+
+### Requirement: RSS unsubscribe data cleanup
+The system SHALL remove operational RSS data owned by a Link when that Link is no longer configured
+as an enabled RSS subscription.
+
+#### Scenario: User disables an enabled subscription
+- **WHEN** a Link with `spec.rss.enabled` set to `true` is updated so that
+  `spec.rss.enabled` is `false`
+- **THEN** the system excludes that Link from subsequent RSS refreshes
+- **AND** the system removes every cached feed item whose link name matches that Link
+- **AND** the system clears the Link's `status.rss`
+- **AND** the system preserves the Link's configured `spec.rss.feedUrls`
+
+#### Scenario: RSS configuration is removed
+- **WHEN** an enabled Link's `spec.rss` configuration is removed
+- **THEN** the system removes every cached feed item whose link name matches that Link
+- **AND** the system clears the Link's `status.rss`
+
+#### Scenario: Saved and hidden items do not survive unsubscribe
+- **WHEN** an unsubscribed Link owns cached feed items marked as read, favorite, read-later, or hidden
+- **THEN** the system removes those items together with the rest of that Link's feed cache
+
+#### Scenario: Existing unsubscribed Link has stale data
+- **WHEN** startup reconciliation observes a Link that is not an enabled RSS subscription and that
+  Link still has cached feed items or `status.rss`
+- **THEN** the system removes the stale cached items and clears `status.rss`
+
+#### Scenario: Unsubscribe cleanup fails
+- **WHEN** the feed item store fails while cleaning an unsubscribed Link
+- **THEN** the system does not clear the Link's `status.rss` as though cleanup succeeded
+- **AND** a later reconciliation can retry the idempotent cleanup
+
+#### Scenario: Refresh completes after unsubscribe
+- **WHEN** an RSS refresh begins while a Link is enabled and the Link is unsubscribed before that
+  refresh completes
+- **THEN** the refresh does not leave cached feed items for that Link
+- **AND** the refresh does not restore `status.rss`
+
+#### Scenario: Subscription is enabled again
+- **WHEN** a previously unsubscribed Link is enabled again with one or more feed URLs
+- **THEN** the existing initial refresh flow fetches the subscription into an empty Link cache
+- **AND** the system derives new RSS runtime status from that refresh
+
+### Requirement: Console RSS unsubscribe confirmation
+The Console SHALL warn administrators before saving a Link change that ends an enabled RSS
+subscription.
+
+#### Scenario: Administrator confirms unsubscribe
+- **WHEN** an administrator saves a Link after changing RSS from enabled to disabled
+- **THEN** the Console asks for confirmation that all cached RSS items, including saved and hidden
+  items, will be permanently removed
+- **AND** after confirmation the Console submits the Link update
+- **AND** after a successful update the Console invalidates affected Link, feed item, unread, and
+  item-summary queries
+
+#### Scenario: Administrator cancels unsubscribe
+- **WHEN** an administrator cancels the RSS unsubscribe confirmation
+- **THEN** the Console does not submit the Link update
+
+#### Scenario: Administrator edits an already disabled subscription
+- **WHEN** an administrator saves other changes to a Link whose RSS subscription was already disabled
+- **THEN** the Console does not show the unsubscribe confirmation

--- a/src/main/java/run/halo/links/LinkReconciler.java
+++ b/src/main/java/run/halo/links/LinkReconciler.java
@@ -1,7 +1,7 @@
 package run.halo.links;
 
 import java.util.Set;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import run.halo.app.extension.ExtensionClient;
 import run.halo.app.extension.ExtensionUtil;
@@ -10,9 +10,9 @@ import run.halo.app.extension.controller.ControllerBuilder;
 import run.halo.app.extension.controller.Reconciler;
 import run.halo.links.extension.Link;
 import run.halo.links.rss.LinkFeedItemStore;
+import run.halo.links.rss.LinkFeedOperationCoordinator;
 
 @Component
-@RequiredArgsConstructor
 public class LinkReconciler implements Reconciler<Reconciler.Request> {
 
     static final String FINALIZER = "link.halo.run/rss-cache-cleanup";
@@ -21,8 +21,27 @@ public class LinkReconciler implements Reconciler<Reconciler.Request> {
 
     private final LinkFeedItemStore itemStore;
 
+    private final LinkFeedOperationCoordinator operationCoordinator;
+
+    @Autowired
+    public LinkReconciler(ExtensionClient client, LinkFeedItemStore itemStore,
+        LinkFeedOperationCoordinator operationCoordinator) {
+        this.client = client;
+        this.itemStore = itemStore;
+        this.operationCoordinator = operationCoordinator;
+    }
+
+    LinkReconciler(ExtensionClient client, LinkFeedItemStore itemStore) {
+        this(client, itemStore, new LinkFeedOperationCoordinator());
+    }
+
     @Override
     public Result reconcile(Request request) {
+        return operationCoordinator.coordinateBlocking(request.name(),
+            () -> reconcileLocked(request));
+    }
+
+    private Result reconcileLocked(Request request) {
         client.fetch(Link.class, request.name()).ifPresent(link -> {
             var metadata = link.getMetadata();
             if (metadata == null) {

--- a/src/main/java/run/halo/links/LinkReconciler.java
+++ b/src/main/java/run/halo/links/LinkReconciler.java
@@ -37,9 +37,23 @@ public class LinkReconciler implements Reconciler<Reconciler.Request> {
             }
             if (ExtensionUtil.addFinalizers(metadata, Set.of(FINALIZER))) {
                 client.update(link);
+                return;
+            }
+            if (!isRssEnabled(link)) {
+                itemStore.deleteByLinkName(request.name());
+                if (link.getStatus().getRss() != null) {
+                    link.getStatus().setRss(null);
+                    client.update(link);
+                }
             }
         });
         return Result.doNotRetry();
+    }
+
+    private static boolean isRssEnabled(Link link) {
+        return link.getSpec() != null
+            && link.getSpec().getRss() != null
+            && Boolean.TRUE.equals(link.getSpec().getRss().getEnabled());
     }
 
     @Override

--- a/src/main/java/run/halo/links/rss/DefaultLinkFeedService.java
+++ b/src/main/java/run/halo/links/rss/DefaultLinkFeedService.java
@@ -350,6 +350,9 @@ public class DefaultLinkFeedService implements LinkFeedService {
         int attemptsRemaining) {
         return fetchLatestLink(linkName)
             .flatMap(link -> {
+                if (!isRssEnabled(link)) {
+                    return cleanupUnsubscribedLink(link);
+                }
                 applyStatus(link, result);
                 return client.update(link);
             })
@@ -399,6 +402,9 @@ public class DefaultLinkFeedService implements LinkFeedService {
         int attemptsRemaining) {
         return fetchLatestLink(linkName)
             .flatMap(link -> {
+                if (!isRssEnabled(link)) {
+                    return cleanupUnsubscribedLink(link);
+                }
                 Link.RssStatus status = Optional.ofNullable(link.getStatus().getRss())
                     .orElseGet(Link.RssStatus::new);
                 status.setLastFetchedAt(Instant.now());
@@ -411,6 +417,15 @@ public class DefaultLinkFeedService implements LinkFeedService {
             .onErrorResume(statusError -> shouldRetryStatusUpdate(statusError, attemptsRemaining)
                 ? updateFailureStatus(linkName, error, attemptsRemaining - 1)
                 : Mono.error(statusError));
+    }
+
+    private Mono<Link> cleanupUnsubscribedLink(Link link) {
+        itemStore.deleteByLinkName(link.getMetadata().getName());
+        if (link.getStatus().getRss() == null) {
+            return Mono.just(link);
+        }
+        link.getStatus().setRss(null);
+        return client.update(link);
     }
 
     private static boolean shouldRetryStatusUpdate(Throwable error, int attemptsRemaining) {

--- a/src/main/java/run/halo/links/rss/DefaultLinkFeedService.java
+++ b/src/main/java/run/halo/links/rss/DefaultLinkFeedService.java
@@ -21,11 +21,11 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
@@ -36,7 +36,6 @@ import run.halo.app.extension.ReactiveExtensionClient;
 import run.halo.links.extension.Link;
 
 @Component
-@RequiredArgsConstructor
 @Slf4j
 public class DefaultLinkFeedService implements LinkFeedService {
 
@@ -53,6 +52,23 @@ public class DefaultLinkFeedService implements LinkFeedService {
     private final LinkFeedItemStore itemStore;
     private final LinkFeedRetentionService retentionService;
     private final LinkFeedFetcher feedFetcher;
+    private final LinkFeedOperationCoordinator operationCoordinator;
+
+    @Autowired
+    public DefaultLinkFeedService(ReactiveExtensionClient client, LinkFeedItemStore itemStore,
+        LinkFeedRetentionService retentionService, LinkFeedFetcher feedFetcher,
+        LinkFeedOperationCoordinator operationCoordinator) {
+        this.client = client;
+        this.itemStore = itemStore;
+        this.retentionService = retentionService;
+        this.feedFetcher = feedFetcher;
+        this.operationCoordinator = operationCoordinator;
+    }
+
+    DefaultLinkFeedService(ReactiveExtensionClient client, LinkFeedItemStore itemStore,
+        LinkFeedRetentionService retentionService, LinkFeedFetcher feedFetcher) {
+        this(client, itemStore, retentionService, feedFetcher, new LinkFeedOperationCoordinator());
+    }
 
     @Override
     public Mono<LinkFeedDiscoveryResult> discover(String websiteUrl) {
@@ -62,6 +78,10 @@ public class DefaultLinkFeedService implements LinkFeedService {
 
     @Override
     public Mono<LinkFeedRefreshResult> refresh(String linkName) {
+        return operationCoordinator.coordinate(linkName, () -> refreshCoordinated(linkName));
+    }
+
+    private Mono<LinkFeedRefreshResult> refreshCoordinated(String linkName) {
         return client.fetch(Link.class, linkName)
             .switchIfEmpty(Mono.error(new ResponseStatusException(HttpStatus.NOT_FOUND,
                 "Link not found: " + linkName)))
@@ -76,8 +96,14 @@ public class DefaultLinkFeedService implements LinkFeedService {
                         .doOnError(statusError -> log.warn("[plugin-links] Failed to update RSS "
                             + "failure status for link {}", linkName, statusError))
                         .onErrorResume(statusError -> Mono.empty())
-                        .then(Mono.error(error)))
-                    .flatMap(result -> updateStatus(linkName, result).thenReturn(result));
+                        .flatMap(published -> published
+                            ? Mono.<LinkFeedRefreshResult>error(error)
+                            : DefaultLinkFeedService.<LinkFeedRefreshResult>staleRefreshError())
+                        .switchIfEmpty(Mono.error(error)))
+                    .flatMap(result -> updateStatus(linkName, result)
+                        .flatMap(published -> published
+                            ? Mono.just(result)
+                            : staleRefreshError()));
             });
     }
 
@@ -342,23 +368,24 @@ public class DefaultLinkFeedService implements LinkFeedService {
         return result;
     }
 
-    private Mono<Link> updateStatus(String linkName, LinkFeedRefreshResult result) {
+    private Mono<Boolean> updateStatus(String linkName, LinkFeedRefreshResult result) {
         return updateStatus(linkName, result, MAX_STATUS_UPDATE_ATTEMPTS);
     }
 
-    private Mono<Link> updateStatus(String linkName, LinkFeedRefreshResult result,
+    private Mono<Boolean> updateStatus(String linkName, LinkFeedRefreshResult result,
         int attemptsRemaining) {
         return fetchLatestLink(linkName)
             .flatMap(link -> {
                 if (!isRssEnabled(link)) {
-                    return cleanupUnsubscribedLink(link);
+                    return cleanupUnsubscribedLink(linkName, link, attemptsRemaining);
                 }
                 applyStatus(link, result);
-                return client.update(link);
-            })
-            .onErrorResume(error -> shouldRetryStatusUpdate(error, attemptsRemaining)
-                ? updateStatus(linkName, result, attemptsRemaining - 1)
-                : Mono.error(error));
+                return client.update(link)
+                    .thenReturn(true)
+                    .onErrorResume(error -> shouldRetryStatusUpdate(error, attemptsRemaining)
+                        ? updateStatus(linkName, result, attemptsRemaining - 1)
+                        : Mono.error(error));
+            });
     }
 
     private Mono<Link> fetchLatestLink(String linkName) {
@@ -394,16 +421,16 @@ public class DefaultLinkFeedService implements LinkFeedService {
         link.getStatus().setRss(status);
     }
 
-    private Mono<Link> updateFailureStatus(String linkName, Throwable error) {
+    private Mono<Boolean> updateFailureStatus(String linkName, Throwable error) {
         return updateFailureStatus(linkName, error, MAX_STATUS_UPDATE_ATTEMPTS);
     }
 
-    private Mono<Link> updateFailureStatus(String linkName, Throwable error,
+    private Mono<Boolean> updateFailureStatus(String linkName, Throwable error,
         int attemptsRemaining) {
         return fetchLatestLink(linkName)
             .flatMap(link -> {
                 if (!isRssEnabled(link)) {
-                    return cleanupUnsubscribedLink(link);
+                    return cleanupUnsubscribedLink(linkName, link, attemptsRemaining);
                 }
                 Link.RssStatus status = Optional.ofNullable(link.getStatus().getRss())
                     .orElseGet(Link.RssStatus::new);
@@ -412,11 +439,29 @@ public class DefaultLinkFeedService implements LinkFeedService {
                 status.setFailureCount(Optional.ofNullable(status.getFailureCount()).orElse(0)
                     + 1);
                 link.getStatus().setRss(status);
-                return client.update(link);
-            })
-            .onErrorResume(statusError -> shouldRetryStatusUpdate(statusError, attemptsRemaining)
-                ? updateFailureStatus(linkName, error, attemptsRemaining - 1)
-                : Mono.error(statusError));
+                return client.update(link)
+                    .thenReturn(true)
+                    .onErrorResume(statusError -> shouldRetryStatusUpdate(statusError,
+                            attemptsRemaining)
+                        ? updateFailureStatus(linkName, error, attemptsRemaining - 1)
+                        : Mono.error(statusError));
+            });
+    }
+
+    private Mono<Boolean> cleanupUnsubscribedLink(String linkName, Link link,
+        int attemptsRemaining) {
+        return cleanupUnsubscribedLink(link)
+            .thenReturn(false)
+            .onErrorResume(error -> {
+                if (!shouldRetryStatusUpdate(error, attemptsRemaining)) {
+                    return Mono.error(error);
+                }
+                return fetchLatestLink(linkName)
+                    .flatMap(latestLink -> isRssEnabled(latestLink)
+                        ? Mono.just(false)
+                        : cleanupUnsubscribedLink(linkName, latestLink,
+                            attemptsRemaining - 1));
+            });
     }
 
     private Mono<Link> cleanupUnsubscribedLink(Link link) {
@@ -426,6 +471,11 @@ public class DefaultLinkFeedService implements LinkFeedService {
         }
         link.getStatus().setRss(null);
         return client.update(link);
+    }
+
+    private static <T> Mono<T> staleRefreshError() {
+        return Mono.error(new ResponseStatusException(HttpStatus.CONFLICT,
+            "RSS subscription changed while refresh was running."));
     }
 
     private static boolean shouldRetryStatusUpdate(Throwable error, int attemptsRemaining) {

--- a/src/main/java/run/halo/links/rss/LinkFeedOperationCoordinator.java
+++ b/src/main/java/run/halo/links/rss/LinkFeedOperationCoordinator.java
@@ -1,0 +1,73 @@
+package run.halo.links.rss;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Semaphore;
+import java.util.function.Supplier;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+@Component
+public class LinkFeedOperationCoordinator {
+
+    private final Map<String, OperationLock> operations = new ConcurrentHashMap<>();
+
+    public <T> Mono<T> coordinate(String linkName, Supplier<Mono<T>> operation) {
+        return Mono.usingWhen(
+            Mono.fromCallable(() -> acquire(linkName)).subscribeOn(Schedulers.boundedElastic()),
+            ignored -> Mono.defer(operation),
+            lease -> Mono.fromRunnable(() -> release(lease))
+        );
+    }
+
+    public <T> T coordinateBlocking(String linkName, Supplier<T> operation) {
+        Lease lease = acquire(linkName);
+        try {
+            return operation.get();
+        } finally {
+            release(lease);
+        }
+    }
+
+    private Lease acquire(String linkName) {
+        OperationLock operationLock = operations.compute(linkName, (ignored, current) -> {
+            OperationLock selected = current == null ? new OperationLock() : current;
+            selected.references++;
+            return selected;
+        });
+        try {
+            operationLock.semaphore.acquire();
+            return new Lease(linkName, operationLock);
+        } catch (InterruptedException error) {
+            releaseReference(linkName, operationLock);
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while waiting for an RSS Link operation.",
+                error);
+        }
+    }
+
+    private void release(Lease lease) {
+        lease.operationLock.semaphore.release();
+        releaseReference(lease.linkName, lease.operationLock);
+    }
+
+    private void releaseReference(String linkName, OperationLock operationLock) {
+        operations.computeIfPresent(linkName, (ignored, current) -> {
+            if (current != operationLock) {
+                return current;
+            }
+            current.references--;
+            return current.references == 0 ? null : current;
+        });
+    }
+
+    private static final class OperationLock {
+
+        private final Semaphore semaphore = new Semaphore(1);
+        private int references;
+    }
+
+    private record Lease(String linkName, OperationLock operationLock) {
+    }
+}

--- a/src/test/java/run/halo/links/LinkReconcilerTest.java
+++ b/src/test/java/run/halo/links/LinkReconcilerTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.times;
@@ -16,11 +17,15 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
 import run.halo.app.extension.ExtensionClient;
 import run.halo.app.extension.Metadata;
 import run.halo.app.extension.controller.Controller;
@@ -28,6 +33,7 @@ import run.halo.app.extension.controller.ControllerBuilder;
 import run.halo.app.extension.controller.Reconciler;
 import run.halo.links.extension.Link;
 import run.halo.links.rss.LinkFeedItemStore;
+import run.halo.links.rss.LinkFeedOperationCoordinator;
 import run.halo.links.rss.LinkFeedStorageUnavailableException;
 
 @ExtendWith(MockitoExtension.class)
@@ -143,6 +149,42 @@ class LinkReconcilerTest {
         InOrder inOrder = inOrder(itemStore, client);
         inOrder.verify(itemStore).deleteByLinkName("link-without-rss");
         inOrder.verify(client).update(link);
+    }
+
+    @Test
+    void shouldCoordinateCleanupWithOtherOperationsForTheSameLink() throws Exception {
+        Link link = disabledLink("link-disabled");
+        link.getMetadata().setFinalizers(Set.of(LinkReconciler.FINALIZER));
+        link.getStatus().setRss(null);
+        LinkFeedOperationCoordinator operationCoordinator = new LinkFeedOperationCoordinator();
+        LinkReconciler reconciler = new LinkReconciler(client, itemStore, operationCoordinator);
+        CountDownLatch cleanupStarted = new CountDownLatch(1);
+        CountDownLatch continueCleanup = new CountDownLatch(1);
+        CountDownLatch nextOperationStarted = new CountDownLatch(1);
+        when(client.fetch(Link.class, "link-disabled")).thenReturn(Optional.of(link));
+        doAnswer(invocation -> {
+            cleanupStarted.countDown();
+            assertThat(continueCleanup.await(5, TimeUnit.SECONDS)).isTrue();
+            return null;
+        }).when(itemStore).deleteByLinkName("link-disabled");
+
+        CompletableFuture<Reconciler.Result> reconcileResult = CompletableFuture.supplyAsync(() ->
+            reconciler.reconcile(new Reconciler.Request("link-disabled")));
+        assertThat(cleanupStarted.await(5, TimeUnit.SECONDS)).isTrue();
+
+        CompletableFuture<Boolean> nextOperation = operationCoordinator.coordinate(
+            "link-disabled", () -> {
+                nextOperationStarted.countDown();
+                return Mono.just(true);
+            }).toFuture();
+        boolean nextOperationStartedBeforeCleanup =
+            nextOperationStarted.await(300, TimeUnit.MILLISECONDS);
+        continueCleanup.countDown();
+
+        assertThat(reconcileResult.get(5, TimeUnit.SECONDS))
+            .isEqualTo(Reconciler.Result.doNotRetry());
+        assertThat(nextOperation.get(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(nextOperationStartedBeforeCleanup).isFalse();
     }
 
     @Test

--- a/src/test/java/run/halo/links/LinkReconcilerTest.java
+++ b/src/test/java/run/halo/links/LinkReconcilerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
@@ -81,6 +82,104 @@ class LinkReconcilerTest {
         assertThat(result).isEqualTo(Reconciler.Result.doNotRetry());
         verifyNoInteractions(itemStore);
         verify(client).fetch(Link.class, "link-a");
+        verifyNoMoreInteractions(client);
+    }
+
+    @Test
+    void shouldCleanupDisabledSubscriptionAndPreserveFeedUrls() {
+        Link link = disabledLink("link-disabled");
+        link.getMetadata().setFinalizers(Set.of(LinkReconciler.FINALIZER));
+        Link.RssStatus rssStatus = new Link.RssStatus();
+        rssStatus.setItemCount(3L);
+        link.getStatus().setRss(rssStatus);
+        LinkReconciler reconciler = new LinkReconciler(client, itemStore);
+        when(client.fetch(Link.class, "link-disabled")).thenReturn(Optional.of(link));
+
+        Reconciler.Result result = reconciler.reconcile(
+            new Reconciler.Request("link-disabled"));
+
+        assertThat(result).isEqualTo(Reconciler.Result.doNotRetry());
+        assertThat(link.getSpec().getRss().getFeedUrls())
+            .containsExactly("https://example.com/feed.xml");
+        assertThat(link.getStatus().getRss()).isNull();
+        assertThat(link.getMetadata().getFinalizers()).containsExactly(LinkReconciler.FINALIZER);
+        InOrder inOrder = inOrder(itemStore, client);
+        inOrder.verify(itemStore).deleteByLinkName("link-disabled");
+        inOrder.verify(client).update(link);
+    }
+
+    @Test
+    void shouldAddFinalizerBeforeCleaningDisabledSubscription() {
+        Link link = disabledLink("link-unprotected");
+        Link.RssStatus rssStatus = new Link.RssStatus();
+        link.getStatus().setRss(rssStatus);
+        LinkReconciler reconciler = new LinkReconciler(client, itemStore);
+        when(client.fetch(Link.class, "link-unprotected")).thenReturn(Optional.of(link));
+
+        Reconciler.Result result = reconciler.reconcile(
+            new Reconciler.Request("link-unprotected"));
+
+        assertThat(result).isEqualTo(Reconciler.Result.doNotRetry());
+        assertThat(link.getMetadata().getFinalizers()).containsExactly(LinkReconciler.FINALIZER);
+        assertThat(link.getStatus().getRss()).isSameAs(rssStatus);
+        verify(client).update(link);
+        verifyNoInteractions(itemStore);
+    }
+
+    @Test
+    void shouldCleanupLinkWithoutRssConfiguration() {
+        Link link = link("link-without-rss");
+        link.getSpec().setRss(null);
+        link.getMetadata().setFinalizers(Set.of(LinkReconciler.FINALIZER));
+        link.getStatus().setRss(new Link.RssStatus());
+        LinkReconciler reconciler = new LinkReconciler(client, itemStore);
+        when(client.fetch(Link.class, "link-without-rss")).thenReturn(Optional.of(link));
+
+        Reconciler.Result result = reconciler.reconcile(
+            new Reconciler.Request("link-without-rss"));
+
+        assertThat(result).isEqualTo(Reconciler.Result.doNotRetry());
+        assertThat(link.getStatus().getRss()).isNull();
+        InOrder inOrder = inOrder(itemStore, client);
+        inOrder.verify(itemStore).deleteByLinkName("link-without-rss");
+        inOrder.verify(client).update(link);
+    }
+
+    @Test
+    void shouldIdempotentlyRepairDisabledLinkOnStartup() {
+        Link link = disabledLink("link-repaired");
+        link.getMetadata().setFinalizers(Set.of(LinkReconciler.FINALIZER));
+        LinkReconciler reconciler = new LinkReconciler(client, itemStore);
+        when(client.fetch(Link.class, "link-repaired")).thenReturn(Optional.of(link));
+
+        Reconciler.Result result = reconciler.reconcile(
+            new Reconciler.Request("link-repaired"));
+
+        assertThat(result).isEqualTo(Reconciler.Result.doNotRetry());
+        verify(itemStore).deleteByLinkName("link-repaired");
+        verify(client).fetch(Link.class, "link-repaired");
+        verifyNoMoreInteractions(client);
+    }
+
+    @Test
+    void shouldKeepRssStatusWhenDisabledLinkCleanupFails() {
+        Link link = disabledLink("link-pending-cleanup");
+        link.getMetadata().setFinalizers(Set.of(LinkReconciler.FINALIZER));
+        Link.RssStatus rssStatus = new Link.RssStatus();
+        rssStatus.setItemCount(3L);
+        link.getStatus().setRss(rssStatus);
+        LinkReconciler reconciler = new LinkReconciler(client, itemStore);
+        when(client.fetch(Link.class, "link-pending-cleanup")).thenReturn(Optional.of(link));
+        doThrow(new LinkFeedStorageUnavailableException("unavailable"))
+            .when(itemStore).deleteByLinkName("link-pending-cleanup");
+
+        assertThatThrownBy(() -> reconciler.reconcile(
+            new Reconciler.Request("link-pending-cleanup")))
+            .isInstanceOf(LinkFeedStorageUnavailableException.class);
+        assertThat(link.getStatus().getRss()).isSameAs(rssStatus);
+        assertThat(link.getSpec().getRss().getFeedUrls())
+            .containsExactly("https://example.com/feed.xml");
+        verify(client).fetch(Link.class, "link-pending-cleanup");
         verifyNoMoreInteractions(client);
     }
 
@@ -168,6 +267,18 @@ class LinkReconcilerTest {
         Metadata metadata = new Metadata();
         metadata.setName(name);
         link.setMetadata(metadata);
+        Link.LinkSpec spec = new Link.LinkSpec();
+        Link.RssSpec rss = new Link.RssSpec();
+        rss.setEnabled(true);
+        rss.setFeedUrls(List.of("https://example.com/feed.xml"));
+        spec.setRss(rss);
+        link.setSpec(spec);
+        return link;
+    }
+
+    private static Link disabledLink(String name) {
+        Link link = link(name);
+        link.getSpec().getRss().setEnabled(false);
         return link;
     }
 

--- a/src/test/java/run/halo/links/rss/DefaultLinkFeedServiceTest.java
+++ b/src/test/java/run/halo/links/rss/DefaultLinkFeedServiceTest.java
@@ -1,11 +1,13 @@
 package run.halo.links.rss;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -18,6 +20,11 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.jsoup.Jsoup;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -446,20 +453,40 @@ class DefaultLinkFeedServiceTest {
         Link disabledLink = rssLink("link-a", "https://example.com/feed.xml");
         disabledLink.getSpec().getRss().setEnabled(false);
         disabledLink.getStatus().setRss(new Link.RssStatus());
+        AtomicReference<Link> currentLink = new AtomicReference<>(initialLink);
+        CountDownLatch refreshStarted = new CountDownLatch(1);
+        CountDownLatch continueRefresh = new CountDownLatch(1);
 
         when(client.fetch(Link.class, "link-a"))
-            .thenReturn(Mono.just(initialLink), Mono.just(disabledLink));
+            .thenAnswer(invocation -> Mono.defer(() -> Mono.just(currentLink.get())));
         when(client.update(any(Link.class))).thenAnswer(invocation ->
             Mono.just(invocation.getArgument(0)));
         when(itemStore.upsertAll(anyList())).thenReturn(1);
         when(itemStore.countByLinkNameAndFeedUrl("link-a", "https://example.com/feed.xml"))
             .thenReturn(1L);
         when(feedFetcher.fetchFeed(eq("https://example.com/feed.xml"), any(), any()))
-            .thenReturn(feedResult("https://example.com/feed.xml", 200, feedXml()));
+            .thenAnswer(invocation -> {
+                refreshStarted.countDown();
+                assertThat(continueRefresh.await(5, TimeUnit.SECONDS)).isTrue();
+                return feedResult("https://example.com/feed.xml", 200, feedXml());
+            });
 
         StepVerifier.create(service.refresh("link-a"))
-            .assertNext(result -> assertThat(result.getFetchedItemCount()).isEqualTo(1))
-            .verifyComplete();
+            .then(() -> {
+                try {
+                    assertThat(refreshStarted.await(5, TimeUnit.SECONDS)).isTrue();
+                } catch (InterruptedException error) {
+                    Thread.currentThread().interrupt();
+                    throw new AssertionError(error);
+                }
+                currentLink.set(disabledLink);
+                continueRefresh.countDown();
+            })
+            .expectErrorSatisfies(error -> assertThat(error)
+                .isInstanceOf(ResponseStatusException.class)
+                .extracting(candidate -> ((ResponseStatusException) candidate).getStatusCode())
+                .isEqualTo(HttpStatus.CONFLICT))
+            .verify();
 
         verify(itemStore).deleteByLinkName("link-a");
         assertThat(disabledLink.getStatus().getRss()).isNull();
@@ -476,24 +503,123 @@ class DefaultLinkFeedServiceTest {
         LinkFeedFetcher feedFetcher = mock(LinkFeedFetcher.class);
         DefaultLinkFeedService service =
             new DefaultLinkFeedService(client, itemStore, retentionService, feedFetcher);
-        Link initialLink = rssLink("link-a", "ftp://example.com/feed.xml");
+        Link initialLink = rssLink("link-a", "https://example.com/feed.xml");
         Link unsubscribedLink = rssLink("link-a", "https://example.com/feed.xml");
         unsubscribedLink.getSpec().setRss(null);
         unsubscribedLink.getStatus().setRss(new Link.RssStatus());
+        AtomicReference<Link> currentLink = new AtomicReference<>(initialLink);
+        CountDownLatch refreshStarted = new CountDownLatch(1);
+        CountDownLatch continueRefresh = new CountDownLatch(1);
 
         when(client.fetch(Link.class, "link-a"))
-            .thenReturn(Mono.just(initialLink), Mono.just(unsubscribedLink));
+            .thenAnswer(invocation -> Mono.defer(() -> Mono.just(currentLink.get())));
         when(client.update(any(Link.class))).thenAnswer(invocation ->
             Mono.just(invocation.getArgument(0)));
+        when(feedFetcher.fetchFeed(eq("https://example.com/feed.xml"), any(), any()))
+            .thenAnswer(invocation -> {
+                refreshStarted.countDown();
+                assertThat(continueRefresh.await(5, TimeUnit.SECONDS)).isTrue();
+                throw new IllegalArgumentException(
+                    "RSS feed URL must be an absolute HTTP or HTTPS URL.");
+            });
 
         StepVerifier.create(service.refresh("link-a"))
+            .then(() -> {
+                try {
+                    assertThat(refreshStarted.await(5, TimeUnit.SECONDS)).isTrue();
+                } catch (InterruptedException error) {
+                    Thread.currentThread().interrupt();
+                    throw new AssertionError(error);
+                }
+                currentLink.set(unsubscribedLink);
+                continueRefresh.countDown();
+            })
             .expectErrorSatisfies(error -> assertThat(error)
-                .hasMessageContaining("absolute HTTP or HTTPS URL"))
+                .isInstanceOf(ResponseStatusException.class)
+                .extracting(candidate -> ((ResponseStatusException) candidate).getStatusCode())
+                .isEqualTo(HttpStatus.CONFLICT))
             .verify();
 
         verify(itemStore).deleteByLinkName("link-a");
         assertThat(unsubscribedLink.getStatus().getRss()).isNull();
         verify(client).update(unsubscribedLink);
+    }
+
+    @Test
+    void shouldFinishUnsubscribeCleanupBeforeRefreshingReenabledSubscription() throws Exception {
+        ReactiveExtensionClient client = mock(ReactiveExtensionClient.class);
+        LinkFeedItemStore itemStore = mock(LinkFeedItemStore.class);
+        LinkFeedRetentionService retentionService = mock(LinkFeedRetentionService.class);
+        LinkFeedFetcher feedFetcher = mock(LinkFeedFetcher.class);
+        LinkFeedOperationCoordinator operationCoordinator = new LinkFeedOperationCoordinator();
+        DefaultLinkFeedService service = new DefaultLinkFeedService(client, itemStore,
+            retentionService, feedFetcher, operationCoordinator);
+        Link initialLink = rssLink("link-a", "https://example.com/feed.xml");
+        Link disabledLink = rssLink("link-a", "https://example.com/feed.xml");
+        disabledLink.getSpec().getRss().setEnabled(false);
+        disabledLink.getStatus().setRss(new Link.RssStatus());
+        Link reenabledLink = rssLink("link-a", "https://example.com/feed.xml");
+        AtomicReference<Link> currentLink = new AtomicReference<>(initialLink);
+        AtomicInteger fetchCount = new AtomicInteger();
+        CountDownLatch firstRefreshStarted = new CountDownLatch(1);
+        CountDownLatch continueFirstRefresh = new CountDownLatch(1);
+        CountDownLatch cleanupStarted = new CountDownLatch(1);
+        CountDownLatch continueCleanup = new CountDownLatch(1);
+        CountDownLatch secondRefreshStarted = new CountDownLatch(1);
+
+        when(client.fetch(Link.class, "link-a"))
+            .thenAnswer(invocation -> Mono.defer(() -> Mono.just(currentLink.get())));
+        when(client.update(any(Link.class))).thenAnswer(invocation -> {
+            Link updatedLink = invocation.getArgument(0);
+            if (!Boolean.TRUE.equals(updatedLink.getSpec().getRss().getEnabled())) {
+                return Mono.error(new ResponseStatusException(HttpStatus.CONFLICT,
+                    "resource version conflict"));
+            }
+            return Mono.just(updatedLink);
+        });
+        when(itemStore.upsertAll(anyList())).thenReturn(1);
+        when(itemStore.countByLinkNameAndFeedUrl("link-a", "https://example.com/feed.xml"))
+            .thenReturn(1L);
+        when(feedFetcher.fetchFeed(eq("https://example.com/feed.xml"), any(), any()))
+            .thenAnswer(invocation -> {
+                if (fetchCount.incrementAndGet() == 1) {
+                    firstRefreshStarted.countDown();
+                    assertThat(continueFirstRefresh.await(5, TimeUnit.SECONDS)).isTrue();
+                } else {
+                    secondRefreshStarted.countDown();
+                }
+                return feedResult("https://example.com/feed.xml", 200, feedXml());
+            });
+        doAnswer(invocation -> {
+            cleanupStarted.countDown();
+            assertThat(continueCleanup.await(5, TimeUnit.SECONDS)).isTrue();
+            return null;
+        }).when(itemStore).deleteByLinkName("link-a");
+
+        CompletableFuture<LinkFeedRefreshResult> firstRefresh =
+            service.refresh("link-a").toFuture();
+        assertThat(firstRefreshStarted.await(5, TimeUnit.SECONDS)).isTrue();
+        currentLink.set(disabledLink);
+        continueFirstRefresh.countDown();
+        assertThat(cleanupStarted.await(5, TimeUnit.SECONDS)).isTrue();
+
+        currentLink.set(reenabledLink);
+        CompletableFuture<LinkFeedRefreshResult> secondRefresh =
+            service.refresh("link-a").toFuture();
+        boolean secondRefreshStartedBeforeCleanup =
+            secondRefreshStarted.await(300, TimeUnit.MILLISECONDS);
+        continueCleanup.countDown();
+
+        assertThat(secondRefreshStartedBeforeCleanup).isFalse();
+        assertThatThrownBy(() -> firstRefresh.get(5, TimeUnit.SECONDS))
+            .cause()
+            .isInstanceOf(ResponseStatusException.class)
+            .extracting(error -> ((ResponseStatusException) error).getStatusCode())
+            .isEqualTo(HttpStatus.CONFLICT);
+        assertThat(secondRefresh.get(5, TimeUnit.SECONDS)).isNotNull();
+        verify(itemStore, times(2)).upsertAll(anyList());
+        verify(itemStore).deleteByLinkName("link-a");
+        verify(client, times(2)).update(any(Link.class));
     }
 
     @Test

--- a/src/test/java/run/halo/links/rss/DefaultLinkFeedServiceTest.java
+++ b/src/test/java/run/halo/links/rss/DefaultLinkFeedServiceTest.java
@@ -435,6 +435,68 @@ class DefaultLinkFeedServiceTest {
     }
 
     @Test
+    void shouldCleanupSuccessfulRefreshWhenLinkWasDisabledInFlight() throws Exception {
+        ReactiveExtensionClient client = mock(ReactiveExtensionClient.class);
+        LinkFeedItemStore itemStore = mock(LinkFeedItemStore.class);
+        LinkFeedRetentionService retentionService = mock(LinkFeedRetentionService.class);
+        LinkFeedFetcher feedFetcher = mock(LinkFeedFetcher.class);
+        DefaultLinkFeedService service =
+            new DefaultLinkFeedService(client, itemStore, retentionService, feedFetcher);
+        Link initialLink = rssLink("link-a", "https://example.com/feed.xml");
+        Link disabledLink = rssLink("link-a", "https://example.com/feed.xml");
+        disabledLink.getSpec().getRss().setEnabled(false);
+        disabledLink.getStatus().setRss(new Link.RssStatus());
+
+        when(client.fetch(Link.class, "link-a"))
+            .thenReturn(Mono.just(initialLink), Mono.just(disabledLink));
+        when(client.update(any(Link.class))).thenAnswer(invocation ->
+            Mono.just(invocation.getArgument(0)));
+        when(itemStore.upsertAll(anyList())).thenReturn(1);
+        when(itemStore.countByLinkNameAndFeedUrl("link-a", "https://example.com/feed.xml"))
+            .thenReturn(1L);
+        when(feedFetcher.fetchFeed(eq("https://example.com/feed.xml"), any(), any()))
+            .thenReturn(feedResult("https://example.com/feed.xml", 200, feedXml()));
+
+        StepVerifier.create(service.refresh("link-a"))
+            .assertNext(result -> assertThat(result.getFetchedItemCount()).isEqualTo(1))
+            .verifyComplete();
+
+        verify(itemStore).deleteByLinkName("link-a");
+        assertThat(disabledLink.getStatus().getRss()).isNull();
+        assertThat(disabledLink.getSpec().getRss().getFeedUrls())
+            .containsExactly("https://example.com/feed.xml");
+        verify(client).update(disabledLink);
+    }
+
+    @Test
+    void shouldCleanupFailedRefreshWhenRssWasRemovedInFlight() {
+        ReactiveExtensionClient client = mock(ReactiveExtensionClient.class);
+        LinkFeedItemStore itemStore = mock(LinkFeedItemStore.class);
+        LinkFeedRetentionService retentionService = mock(LinkFeedRetentionService.class);
+        LinkFeedFetcher feedFetcher = mock(LinkFeedFetcher.class);
+        DefaultLinkFeedService service =
+            new DefaultLinkFeedService(client, itemStore, retentionService, feedFetcher);
+        Link initialLink = rssLink("link-a", "ftp://example.com/feed.xml");
+        Link unsubscribedLink = rssLink("link-a", "https://example.com/feed.xml");
+        unsubscribedLink.getSpec().setRss(null);
+        unsubscribedLink.getStatus().setRss(new Link.RssStatus());
+
+        when(client.fetch(Link.class, "link-a"))
+            .thenReturn(Mono.just(initialLink), Mono.just(unsubscribedLink));
+        when(client.update(any(Link.class))).thenAnswer(invocation ->
+            Mono.just(invocation.getArgument(0)));
+
+        StepVerifier.create(service.refresh("link-a"))
+            .expectErrorSatisfies(error -> assertThat(error)
+                .hasMessageContaining("absolute HTTP or HTTPS URL"))
+            .verify();
+
+        verify(itemStore).deleteByLinkName("link-a");
+        assertThat(unsubscribedLink.getStatus().getRss()).isNull();
+        verify(client).update(unsubscribedLink);
+    }
+
+    @Test
     void shouldUpdatePerFeedFailureStatusWhenRefreshFails() {
         ReactiveExtensionClient client = mock(ReactiveExtensionClient.class);
         LinkFeedItemStore itemStore = mock(LinkFeedItemStore.class);


### PR DESCRIPTION
## What

- remove cached feed items and clear RSS runtime status when a link is unsubscribed
- recheck the latest subscription state before publishing refresh results to cover in-flight refreshes
- confirm destructive unsubscribe actions in Console and invalidate affected RSS queries

## Why

Disabling RSS tracking stopped future refreshes but left cached feed items behind. Those stale items remained in aggregate RSS views and appeared to belong to a deleted link.

Fixes #162.

## Reproduction

1. Enable RSS tracking for a link and refresh its feed.
2. Edit the link and disable RSS tracking.
3. Open the RSS updates page.
4. Observe that cached entries from the unsubscribed link remain and are labeled as coming from a deleted link.

## Verification

- `./gradlew build`
- `cd console && pnpm type-check`
- `cd console && pnpm exec eslint .`
- `cd console && pnpm exec prettier --check src/components/LinkEditingModal.vue src/components/__tests__/LinkEditingModal.test.ts`
- `openspec validate link-rss-feed --type spec --strict`
- `git diff --check`
